### PR TITLE
読書管理アプリのMVP機能を実装

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.7.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 
 include ":app"

--- a/docs/ANDROID_BUILD_TOOLS.md
+++ b/docs/ANDROID_BUILD_TOOLS.md
@@ -1,0 +1,103 @@
+# Android ビルドツール バージョン情報
+
+このドキュメントでは、プロジェクトで使用している Android ビルドツールのバージョンと設定ファイルの場所をまとめています。
+
+## 現在のバージョン
+
+| ツール | バージョン | 最終更新日 |
+|--------|-----------|-----------|
+| Gradle | 8.10.2 | 2026-02-05 |
+| Android Gradle Plugin (AGP) | 8.7.2 | 2026-02-05 |
+| Kotlin | 1.9.22 | 2026-02-05 |
+| Java Compatibility | 1.8 | - |
+
+## 設定ファイルの場所
+
+### Gradle バージョン
+
+**ファイル**: `android/gradle/wrapper/gradle-wrapper.properties`
+
+```properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+```
+
+### AGP / Kotlin バージョン
+
+**ファイル**: `android/settings.gradle`
+
+```gradle
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.7.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+}
+```
+
+### アプリ固有の設定
+
+**ファイル**: `android/app/build.gradle`
+
+- `namespace`: com.book_manager.book_manager
+- `applicationId`: com.book_manager.book_manager
+- `compileSdk`: Flutter SDK に依存
+- `minSdk`: Flutter SDK に依存
+- `targetSdk`: Flutter SDK に依存
+
+## バージョン互換性
+
+Gradle と AGP には互換性の制約があります。アップグレード時は以下の組み合わせを参考にしてください。
+
+| AGP バージョン | 必要な Gradle バージョン |
+|---------------|------------------------|
+| 8.7.x | 8.9 以上 |
+| 8.5.x | 8.7 以上 |
+| 8.4.x | 8.6 以上 |
+| 8.3.x | 8.4 以上 |
+| 8.1.x | 8.0 以上 |
+
+参考: [Android Gradle Plugin リリースノート](https://developer.android.com/build/releases/gradle-plugin)
+
+## アップグレード手順
+
+### 1. Gradle のアップグレード
+
+`android/gradle/wrapper/gradle-wrapper.properties` を編集:
+
+```properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-{VERSION}-all.zip
+```
+
+### 2. AGP のアップグレード
+
+`android/settings.gradle` の plugins ブロックを編集:
+
+```gradle
+id "com.android.application" version "{VERSION}" apply false
+```
+
+### 3. クリーンビルド
+
+```bash
+flutter clean
+flutter pub get
+flutter run
+```
+
+## トラブルシューティング
+
+### よくあるエラー
+
+#### 「Gradle version will soon be dropped」
+
+Flutter が要求する最低 Gradle バージョンを満たしていない場合に発生。`gradle-wrapper.properties` の `distributionUrl` を更新してください。
+
+#### 「AGP version is lower than Flutter's minimum」
+
+Flutter が要求する最低 AGP バージョンを満たしていない場合に発生。`settings.gradle` の AGP バージョンを更新してください。
+
+### 参考リンク
+
+- [Gradle Releases](https://gradle.org/releases/)
+- [Android Gradle Plugin Releases](https://developer.android.com/build/releases/gradle-plugin)
+- [Kotlin Releases](https://kotlinlang.org/docs/releases.html)
+- [Flutter Android Setup](https://docs.flutter.dev/get-started/install/macos#android-setup)

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		104885AE13755FC91DDE1DD1 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67EEE0FCA47823C9662E0031 /* Pods_RunnerTests.framework */; };
+		129DFEDECFD9CEC54E410F36 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58353B504653466A28807A5A /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
@@ -45,6 +47,11 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		4994C5EC0C937994D5E42F10 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		58353B504653466A28807A5A /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		60758FA5F92D6A81F74EA685 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		67EEE0FCA47823C9662E0031 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DE194063EAA0091925A1800 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -55,6 +62,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A5771786CEB4DDC11B767B8E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		AC2BF2C80E73DF58AEBF9FF9 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		B4044810B05E363A553C7D12 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,18 +72,50 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				129DFEDECFD9CEC54E410F36 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B8509A5BC5B407C932DF4A3A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				104885AE13755FC91DDE1DD1 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		087D75A91F0F7CEBA471A3CF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A5771786CEB4DDC11B767B8E /* Pods-Runner.debug.xcconfig */,
+				B4044810B05E363A553C7D12 /* Pods-Runner.release.xcconfig */,
+				6DE194063EAA0091925A1800 /* Pods-Runner.profile.xcconfig */,
+				60758FA5F92D6A81F74EA685 /* Pods-RunnerTests.debug.xcconfig */,
+				4994C5EC0C937994D5E42F10 /* Pods-RunnerTests.release.xcconfig */,
+				AC2BF2C80E73DF58AEBF9FF9 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		9111EE4B2362B9A66258DD20 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				58353B504653466A28807A5A /* Pods_Runner.framework */,
+				67EEE0FCA47823C9662E0031 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +136,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				087D75A91F0F7CEBA471A3CF /* Pods */,
+				9111EE4B2362B9A66258DD20 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				E29AD48C277531C28D4E7D9C /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				B8509A5BC5B407C932DF4A3A /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				F1488A1AE9A4B6BA82056B3E /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				1E04BB3DDFCA5DC3AF12A1CE /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +270,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1E04BB3DDFCA5DC3AF12A1CE /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +317,50 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E29AD48C277531C28D4E7D9C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F1488A1AE9A4B6BA82056B3E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -378,6 +487,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 60758FA5F92D6A81F74EA685 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +505,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4994C5EC0C937994D5E42F10 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +521,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AC2BF2C80E73DF58AEBF9FF9 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -54,11 +55,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -1,0 +1,111 @@
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// SQLiteデータベースヘルパー
+class DatabaseHelper {
+
+  factory DatabaseHelper() {
+    _instance ??= DatabaseHelper._internal();
+    return _instance!;
+  }
+
+  DatabaseHelper._internal();
+  static const _databaseName = 'book_manager.db';
+  static const _databaseVersion = 1;
+
+  static const tableName = 'books';
+
+  // シングルトンインスタンス
+  static DatabaseHelper? _instance;
+  static Database? _database;
+
+  Future<Database> get database async {
+    _database ??= await _initDatabase();
+    return _database!;
+  }
+
+  Future<Database> _initDatabase() async {
+    final databasesPath = await getDatabasesPath();
+    final path = join(databasesPath, _databaseName);
+
+    return await openDatabase(
+      path,
+      version: _databaseVersion,
+      onCreate: _onCreate,
+    );
+  }
+
+  Future<void> _onCreate(Database db, int version) async {
+    await db.execute('''
+      CREATE TABLE $tableName (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        author TEXT,
+        isbn TEXT,
+        cover_url TEXT,
+        status INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        completed_at INTEGER
+      )
+    ''');
+  }
+
+  /// 本を挿入
+  Future<int> insert(Map<String, dynamic> row) async {
+    final db = await database;
+    return await db.insert(tableName, row);
+  }
+
+  /// 全ての本を取得
+  Future<List<Map<String, dynamic>>> queryAll() async {
+    final db = await database;
+    return await db.query(
+      tableName,
+      orderBy: 'created_at DESC',
+    );
+  }
+
+  /// IDで本を取得
+  Future<Map<String, dynamic>?> queryById(String id) async {
+    final db = await database;
+    final results = await db.query(
+      tableName,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+    return results.isNotEmpty ? results.first : null;
+  }
+
+  /// ステータスで本を取得
+  Future<List<Map<String, dynamic>>> queryByStatus(int status) async {
+    final db = await database;
+    return await db.query(
+      tableName,
+      where: 'status = ?',
+      whereArgs: [status],
+      orderBy: 'created_at DESC',
+    );
+  }
+
+  /// 本を更新
+  Future<int> update(Map<String, dynamic> row) async {
+    final db = await database;
+    final id = row['id'];
+    return await db.update(
+      tableName,
+      row,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  /// 本を削除
+  Future<int> delete(String id) async {
+    final db = await database;
+    return await db.delete(
+      tableName,
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,130 +1,46 @@
+import 'package:book_manager/screens/home_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
   runApp(
     const ProviderScope(
-      child: MyApp(),
+      child: BookManagerApp(),
     ),
   );
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class BookManagerApp extends StatelessWidget {
+  const BookManagerApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: '読書管理',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.indigo,
+        ),
         useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+        appBarTheme: const AppBarTheme(
+          centerTitle: true,
+          elevation: 0,
+        ),
+        cardTheme: CardThemeData(
+          elevation: 2,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          filled: true,
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: const HomeScreen(),
     );
   }
 }

--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -1,3 +1,6 @@
+/// copyWithでnullableフィールドをnullにクリアするためのsentinel値
+const _sentinel = Object();
+
 /// 読書ステータス
 enum ReadingStatus {
   unread,   // 未読
@@ -96,25 +99,30 @@ class Book {
   }
 
   /// コピーを作成（一部のフィールドを変更）
+  ///
+  /// nullableフィールド（isbn, coverUrl, completedAt）は明示的にnullを渡すことで
+  /// 値をクリアできます。引数を省略した場合は既存の値が維持されます。
   Book copyWith({
     String? id,
     String? title,
     String? author,
-    String? isbn,
-    String? coverUrl,
+    Object? isbn = _sentinel,
+    Object? coverUrl = _sentinel,
     ReadingStatus? status,
     DateTime? createdAt,
-    DateTime? completedAt,
+    Object? completedAt = _sentinel,
   }) {
     return Book(
       id: id ?? this.id,
       title: title ?? this.title,
       author: author ?? this.author,
-      isbn: isbn ?? this.isbn,
-      coverUrl: coverUrl ?? this.coverUrl,
+      isbn: isbn == _sentinel ? this.isbn : isbn as String?,
+      coverUrl: coverUrl == _sentinel ? this.coverUrl : coverUrl as String?,
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,
-      completedAt: completedAt ?? this.completedAt,
+      completedAt: completedAt == _sentinel
+          ? this.completedAt
+          : completedAt as DateTime?,
     );
   }
 

--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -1,0 +1,129 @@
+/// 読書ステータス
+enum ReadingStatus {
+  unread,   // 未読
+  reading,  // 読書中
+  completed // 読了
+}
+
+/// 読書ステータスの表示名を取得
+extension ReadingStatusExtension on ReadingStatus {
+  String get displayName {
+    switch (this) {
+      case ReadingStatus.unread:
+        return '未読';
+      case ReadingStatus.reading:
+        return '読書中';
+      case ReadingStatus.completed:
+        return '読了';
+    }
+  }
+
+  int get value {
+    switch (this) {
+      case ReadingStatus.unread:
+        return 0;
+      case ReadingStatus.reading:
+        return 1;
+      case ReadingStatus.completed:
+        return 2;
+    }
+  }
+
+  static ReadingStatus fromValue(int value) {
+    switch (value) {
+      case 0:
+        return ReadingStatus.unread;
+      case 1:
+        return ReadingStatus.reading;
+      case 2:
+        return ReadingStatus.completed;
+      default:
+        return ReadingStatus.unread;
+    }
+  }
+}
+
+/// 本のモデル
+class Book {
+
+  const Book({
+    required this.id,
+    required this.title,
+    required this.author,
+    this.isbn,
+    this.coverUrl,
+    required this.status,
+    required this.createdAt,
+    this.completedAt,
+  });
+
+  /// Mapから本を作成
+  factory Book.fromMap(Map<String, dynamic> map) {
+    return Book(
+      id: map['id'] as String,
+      title: map['title'] as String,
+      author: map['author'] as String? ?? '',
+      isbn: map['isbn'] as String?,
+      coverUrl: map['cover_url'] as String?,
+      status: ReadingStatusExtension.fromValue(map['status'] as int),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(map['created_at'] as int),
+      completedAt: map['completed_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['completed_at'] as int)
+          : null,
+    );
+  }
+  final String id;
+  final String title;
+  final String author;
+  final String? isbn;
+  final String? coverUrl;
+  final ReadingStatus status;
+  final DateTime createdAt;
+  final DateTime? completedAt;
+
+  /// データベース用のMapに変換
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'title': title,
+      'author': author,
+      'isbn': isbn,
+      'cover_url': coverUrl,
+      'status': status.value,
+      'created_at': createdAt.millisecondsSinceEpoch,
+      'completed_at': completedAt?.millisecondsSinceEpoch,
+    };
+  }
+
+  /// コピーを作成（一部のフィールドを変更）
+  Book copyWith({
+    String? id,
+    String? title,
+    String? author,
+    String? isbn,
+    String? coverUrl,
+    ReadingStatus? status,
+    DateTime? createdAt,
+    DateTime? completedAt,
+  }) {
+    return Book(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      author: author ?? this.author,
+      isbn: isbn ?? this.isbn,
+      coverUrl: coverUrl ?? this.coverUrl,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      completedAt: completedAt ?? this.completedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Book && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/providers/books_provider.dart
+++ b/lib/providers/books_provider.dart
@@ -1,0 +1,93 @@
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/repositories/book_repository.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// リポジトリのプロバイダー
+final bookRepositoryProvider = Provider<BookRepository>((ref) {
+  return BookRepository();
+});
+
+/// 選択中のフィルターステータス（nullは全て）
+final selectedStatusFilterProvider = StateProvider<ReadingStatus?>((ref) {
+  return null;
+});
+
+/// 本のリストを管理するNotifier
+class BooksNotifier extends AsyncNotifier<List<Book>> {
+  @override
+  Future<List<Book>> build() async {
+    return await _fetchBooks();
+  }
+
+  Future<List<Book>> _fetchBooks() async {
+    final repository = ref.read(bookRepositoryProvider);
+    return await repository.getAllBooks();
+  }
+
+  /// 本を追加
+  Future<void> addBook({
+    required String title,
+    required String author,
+    String? isbn,
+    String? coverUrl,
+    ReadingStatus status = ReadingStatus.unread,
+  }) async {
+    final repository = ref.read(bookRepositoryProvider);
+    await repository.addBook(
+      title: title,
+      author: author,
+      isbn: isbn,
+      coverUrl: coverUrl,
+      status: status,
+    );
+    ref.invalidateSelf();
+  }
+
+  /// 本を更新
+  Future<void> updateBook(Book book) async {
+    final repository = ref.read(bookRepositoryProvider);
+    await repository.updateBook(book);
+    ref.invalidateSelf();
+  }
+
+  /// 本のステータスを更新
+  Future<void> updateBookStatus(String bookId, ReadingStatus status) async {
+    final repository = ref.read(bookRepositoryProvider);
+    final book = await repository.getBookById(bookId);
+    if (book != null) {
+      await repository.updateBook(book.copyWith(status: status));
+      ref.invalidateSelf();
+    }
+  }
+
+  /// 本を削除
+  Future<void> deleteBook(String id) async {
+    final repository = ref.read(bookRepositoryProvider);
+    await repository.deleteBook(id);
+    ref.invalidateSelf();
+  }
+}
+
+/// 本のリストプロバイダー
+final booksProvider = AsyncNotifierProvider<BooksNotifier, List<Book>>(() {
+  return BooksNotifier();
+});
+
+/// フィルタリングされた本のリスト
+final filteredBooksProvider = Provider<AsyncValue<List<Book>>>((ref) {
+  final booksAsync = ref.watch(booksProvider);
+  final selectedStatus = ref.watch(selectedStatusFilterProvider);
+
+  return booksAsync.whenData((books) {
+    if (selectedStatus == null) {
+      return books;
+    }
+    return books.where((book) => book.status == selectedStatus).toList();
+  });
+});
+
+/// 特定の本を取得するプロバイダー
+final bookByIdProvider = FutureProvider.family<Book?, String>((ref, id) async {
+  final repository = ref.read(bookRepositoryProvider);
+  return await repository.getBookById(id);
+});

--- a/lib/repositories/book_repository.dart
+++ b/lib/repositories/book_repository.dart
@@ -55,11 +55,17 @@ class BookRepository {
 
   /// 本を更新
   Future<Book> updateBook(Book book) async {
-    // 読了ステータスに変更された場合、completedAtを設定
-    final updatedBook = book.status == ReadingStatus.completed &&
-            book.completedAt == null
-        ? book.copyWith(completedAt: DateTime.now())
-        : book;
+    final Book updatedBook;
+    if (book.status == ReadingStatus.completed && book.completedAt == null) {
+      // 読了ステータスに変更された場合、completedAtを設定
+      updatedBook = book.copyWith(completedAt: DateTime.now());
+    } else if (book.status != ReadingStatus.completed &&
+        book.completedAt != null) {
+      // 読了以外に変更された場合、completedAtをクリア
+      updatedBook = book.copyWith(completedAt: null);
+    } else {
+      updatedBook = book;
+    }
 
     await _dbHelper.update(updatedBook.toMap());
     return updatedBook;

--- a/lib/repositories/book_repository.dart
+++ b/lib/repositories/book_repository.dart
@@ -1,0 +1,72 @@
+import 'package:book_manager/database/database_helper.dart';
+import 'package:book_manager/models/book.dart';
+import 'package:uuid/uuid.dart';
+
+/// 本のリポジトリ（データアクセス層）
+class BookRepository {
+
+  BookRepository({
+    DatabaseHelper? dbHelper,
+    Uuid? uuid,
+  })  : _dbHelper = dbHelper ?? DatabaseHelper(),
+        _uuid = uuid ?? const Uuid();
+  final DatabaseHelper _dbHelper;
+  final Uuid _uuid;
+
+  /// 本を追加
+  Future<Book> addBook({
+    required String title,
+    required String author,
+    String? isbn,
+    String? coverUrl,
+    ReadingStatus status = ReadingStatus.unread,
+  }) async {
+    final book = Book(
+      id: _uuid.v4(),
+      title: title,
+      author: author,
+      isbn: isbn,
+      coverUrl: coverUrl,
+      status: status,
+      createdAt: DateTime.now(),
+    );
+
+    await _dbHelper.insert(book.toMap());
+    return book;
+  }
+
+  /// 全ての本を取得
+  Future<List<Book>> getAllBooks() async {
+    final maps = await _dbHelper.queryAll();
+    return maps.map((map) => Book.fromMap(map)).toList();
+  }
+
+  /// IDで本を取得
+  Future<Book?> getBookById(String id) async {
+    final map = await _dbHelper.queryById(id);
+    return map != null ? Book.fromMap(map) : null;
+  }
+
+  /// ステータスで本を取得
+  Future<List<Book>> getBooksByStatus(ReadingStatus status) async {
+    final maps = await _dbHelper.queryByStatus(status.value);
+    return maps.map((map) => Book.fromMap(map)).toList();
+  }
+
+  /// 本を更新
+  Future<Book> updateBook(Book book) async {
+    // 読了ステータスに変更された場合、completedAtを設定
+    final updatedBook = book.status == ReadingStatus.completed &&
+            book.completedAt == null
+        ? book.copyWith(completedAt: DateTime.now())
+        : book;
+
+    await _dbHelper.update(updatedBook.toMap());
+    return updatedBook;
+  }
+
+  /// 本を削除
+  Future<void> deleteBook(String id) async {
+    await _dbHelper.delete(id);
+  }
+}

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -1,0 +1,291 @@
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/providers/books_provider.dart';
+import 'package:book_manager/screens/book_form_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 本の詳細画面
+class BookDetailScreen extends ConsumerWidget {
+
+  const BookDetailScreen({super.key, required this.bookId});
+  final String bookId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final bookAsync = ref.watch(bookByIdProvider(bookId));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('本の詳細'),
+        centerTitle: true,
+        actions: [
+          bookAsync.whenOrNull(
+                data: (book) => book != null
+                    ? PopupMenuButton<String>(
+                        onSelected: (value) async {
+                          if (value == 'edit') {
+                            await _navigateToEdit(context, book);
+                          } else if (value == 'delete') {
+                            await _showDeleteDialog(context, ref, book);
+                          }
+                        },
+                        itemBuilder: (context) => [
+                          const PopupMenuItem(
+                            value: 'edit',
+                            child: Row(
+                              children: [
+                                Icon(Icons.edit),
+                                SizedBox(width: 8),
+                                Text('編集'),
+                              ],
+                            ),
+                          ),
+                          PopupMenuItem(
+                            value: 'delete',
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.delete,
+                                  color: Theme.of(context).colorScheme.error,
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  '削除',
+                                  style: TextStyle(
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      )
+                    : null,
+              ) ??
+              const SizedBox.shrink(),
+        ],
+      ),
+      body: bookAsync.when(
+        data: (book) {
+          if (book == null) {
+            return const Center(child: Text('本が見つかりません'));
+          }
+          return _buildContent(context, ref, book);
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stackTrace) => Center(
+          child: Text('エラー: $error'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, WidgetRef ref, Book book) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 表紙画像
+          _buildCoverImage(book),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // タイトル
+                Text(
+                  book.title,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 8),
+
+                // 著者
+                if (book.author.isNotEmpty)
+                  Text(
+                    book.author,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                const SizedBox(height: 16),
+
+                // ステータス変更
+                Text(
+                  '読書ステータス',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                SegmentedButton<ReadingStatus>(
+                  segments: ReadingStatus.values
+                      .map(
+                        (status) => ButtonSegment<ReadingStatus>(
+                          value: status,
+                          label: Text(status.displayName),
+                        ),
+                      )
+                      .toList(),
+                  selected: {book.status},
+                  onSelectionChanged: (Set<ReadingStatus> newSelection) async {
+                    await _updateStatus(ref, book.id, newSelection.first);
+                  },
+                ),
+                const SizedBox(height: 24),
+
+                // 詳細情報
+                _buildInfoSection(context, book),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCoverImage(Book book) {
+    if (book.coverUrl != null && book.coverUrl!.isNotEmpty) {
+      return SizedBox(
+        width: double.infinity,
+        height: 250,
+        child: Image.network(
+          book.coverUrl!,
+          fit: BoxFit.contain,
+          errorBuilder: (context, error, stackTrace) => _buildPlaceholder(),
+        ),
+      );
+    }
+    return _buildPlaceholder();
+  }
+
+  Widget _buildPlaceholder() {
+    return Container(
+      width: double.infinity,
+      height: 200,
+      color: Colors.grey[200],
+      child: Center(
+        child: Icon(
+          Icons.menu_book,
+          size: 80,
+          color: Colors.grey[400],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoSection(BuildContext context, Book book) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '詳細情報',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const Divider(),
+            _buildInfoRow(context, 'ISBN', book.isbn ?? '未設定'),
+            _buildInfoRow(
+              context,
+              '登録日',
+              _formatDate(book.createdAt),
+            ),
+            if (book.completedAt != null)
+              _buildInfoRow(
+                context,
+                '読了日',
+                _formatDate(book.completedAt!),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
+  }
+
+  Future<void> _updateStatus(
+    WidgetRef ref,
+    String bookId,
+    ReadingStatus status,
+  ) async {
+    await ref.read(booksProvider.notifier).updateBookStatus(bookId, status);
+    ref.invalidate(bookByIdProvider(bookId));
+  }
+
+  Future<void> _navigateToEdit(BuildContext context, Book book) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => BookFormScreen(book: book),
+      ),
+    );
+  }
+
+  Future<void> _showDeleteDialog(
+    BuildContext context,
+    WidgetRef ref,
+    Book book,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('本を削除'),
+        content: Text('「${book.title}」を削除しますか？\nこの操作は取り消せません。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      await ref.read(booksProvider.notifier).deleteBook(book.id);
+      if (context.mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('本を削除しました')),
+        );
+      }
+    }
+  }
+}

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -25,6 +25,9 @@ class BookFormScreen extends HookConsumerWidget {
     final selectedStatus = useState(book?.status ?? ReadingStatus.unread);
     final isLoading = useState(false);
 
+    // coverUrlControllerの変更を監視してリビルドをトリガー
+    useListenable(coverUrlController);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(isEditing ? '本を編集' : '本を追加'),

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -73,7 +73,7 @@ class BookFormScreen extends HookConsumerWidget {
                 hintText: 'ISBN番号を入力',
                 border: OutlineInputBorder(),
               ),
-              keyboardType: TextInputType.number,
+              keyboardType: TextInputType.text,
               textInputAction: TextInputAction.next,
             ),
             const SizedBox(height: 16),

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -1,0 +1,264 @@
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/providers/books_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 本の登録・編集画面
+class BookFormScreen extends HookConsumerWidget {
+
+  const BookFormScreen({super.key, this.book});
+  final Book? book;
+
+  bool get isEditing => book != null;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = useMemoized(() => GlobalKey<FormState>());
+
+    final titleController = useTextEditingController(text: book?.title ?? '');
+    final authorController = useTextEditingController(text: book?.author ?? '');
+    final isbnController = useTextEditingController(text: book?.isbn ?? '');
+    final coverUrlController =
+        useTextEditingController(text: book?.coverUrl ?? '');
+
+    final selectedStatus = useState(book?.status ?? ReadingStatus.unread);
+    final isLoading = useState(false);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? '本を編集' : '本を追加'),
+        centerTitle: true,
+      ),
+      body: Form(
+        key: formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // タイトル（必須）
+            TextFormField(
+              controller: titleController,
+              decoration: const InputDecoration(
+                labelText: 'タイトル *',
+                hintText: '本のタイトルを入力',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'タイトルを入力してください';
+                }
+                return null;
+              },
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+
+            // 著者
+            TextFormField(
+              controller: authorController,
+              decoration: const InputDecoration(
+                labelText: '著者',
+                hintText: '著者名を入力',
+                border: OutlineInputBorder(),
+              ),
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+
+            // ISBN
+            TextFormField(
+              controller: isbnController,
+              decoration: const InputDecoration(
+                labelText: 'ISBN',
+                hintText: 'ISBN番号を入力',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.number,
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 16),
+
+            // 表紙画像URL
+            TextFormField(
+              controller: coverUrlController,
+              decoration: const InputDecoration(
+                labelText: '表紙画像URL',
+                hintText: '画像のURLを入力',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.done,
+            ),
+            const SizedBox(height: 24),
+
+            // ステータス選択
+            Text(
+              '読書ステータス',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            SegmentedButton<ReadingStatus>(
+              segments: ReadingStatus.values
+                  .map(
+                    (status) => ButtonSegment<ReadingStatus>(
+                      value: status,
+                      label: Text(status.displayName),
+                    ),
+                  )
+                  .toList(),
+              selected: {selectedStatus.value},
+              onSelectionChanged: (Set<ReadingStatus> newSelection) {
+                selectedStatus.value = newSelection.first;
+              },
+            ),
+            const SizedBox(height: 32),
+
+            // 表紙プレビュー
+            if (coverUrlController.text.isNotEmpty) ...[
+              Text(
+                '表紙プレビュー',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              _CoverPreview(url: coverUrlController.text),
+              const SizedBox(height: 24),
+            ],
+
+            // 保存ボタン
+            FilledButton.icon(
+              onPressed: isLoading.value
+                  ? null
+                  : () => _saveBook(
+                        context,
+                        ref,
+                        formKey,
+                        titleController.text,
+                        authorController.text,
+                        isbnController.text,
+                        coverUrlController.text,
+                        selectedStatus.value,
+                        isLoading,
+                      ),
+              icon: isLoading.value
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.save),
+              label: Text(isEditing ? '更新' : '保存'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _saveBook(
+    BuildContext context,
+    WidgetRef ref,
+    GlobalKey<FormState> formKey,
+    String title,
+    String author,
+    String isbn,
+    String coverUrl,
+    ReadingStatus status,
+    ValueNotifier<bool> isLoading,
+  ) async {
+    if (!formKey.currentState!.validate()) {
+      return;
+    }
+
+    isLoading.value = true;
+
+    try {
+      final notifier = ref.read(booksProvider.notifier);
+
+      if (isEditing) {
+        await notifier.updateBook(
+          book!.copyWith(
+            title: title.trim(),
+            author: author.trim(),
+            isbn: isbn.trim().isEmpty ? null : isbn.trim(),
+            coverUrl: coverUrl.trim().isEmpty ? null : coverUrl.trim(),
+            status: status,
+          ),
+        );
+      } else {
+        await notifier.addBook(
+          title: title.trim(),
+          author: author.trim(),
+          isbn: isbn.trim().isEmpty ? null : isbn.trim(),
+          coverUrl: coverUrl.trim().isEmpty ? null : coverUrl.trim(),
+          status: status,
+        );
+      }
+
+      if (context.mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(isEditing ? '本を更新しました' : '本を追加しました'),
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('エラーが発生しました: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}
+
+class _CoverPreview extends HookWidget {
+
+  const _CoverPreview({required this.url});
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasError = useState(false);
+
+    return Container(
+      height: 200,
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey[300]!),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: hasError.value
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.broken_image, color: Colors.grey[400], size: 48),
+                  const SizedBox(height: 8),
+                  Text(
+                    '画像を読み込めません',
+                    style: TextStyle(color: Colors.grey[500]),
+                  ),
+                ],
+              ),
+            )
+          : ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Image.network(
+                url,
+                fit: BoxFit.contain,
+                errorBuilder: (context, error, stackTrace) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    hasError.value = true;
+                  });
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,138 @@
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/providers/books_provider.dart';
+import 'package:book_manager/screens/book_detail_screen.dart';
+import 'package:book_manager/screens/book_form_screen.dart';
+import 'package:book_manager/widgets/book_card.dart';
+import 'package:book_manager/widgets/status_filter.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// ホーム画面（本一覧）
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filteredBooks = ref.watch(filteredBooksProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('読書管理'),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          // ステータスフィルター
+          const StatusFilter(),
+          // 本の一覧
+          Expanded(
+            child: filteredBooks.when(
+              data: (books) {
+                if (books.isEmpty) {
+                  return _buildEmptyState(context);
+                }
+                return _buildBookGrid(context, books);
+              },
+              loading: () => const Center(
+                child: CircularProgressIndicator(),
+              ),
+              error: (error, stackTrace) => Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      size: 48,
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'エラーが発生しました',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      error.toString(),
+                      style: Theme.of(context).textTheme.bodySmall,
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _navigateToAddBook(context),
+        icon: const Icon(Icons.add),
+        label: const Text('本を追加'),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.library_books_outlined,
+            size: 80,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '本がまだありません',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '右下のボタンから本を追加してください',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Colors.grey[500],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBookGrid(BuildContext context, List<Book> books) {
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        childAspectRatio: 0.65,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+      ),
+      itemCount: books.length,
+      itemBuilder: (context, index) {
+        final book = books[index];
+        return BookCard(
+          book: book,
+          onTap: () => _navigateToDetail(context, book.id),
+        );
+      },
+    );
+  }
+
+  void _navigateToAddBook(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const BookFormScreen(),
+      ),
+    );
+  }
+
+  void _navigateToDetail(BuildContext context, String bookId) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => BookDetailScreen(bookId: bookId),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -120,16 +120,16 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
-  void _navigateToAddBook(BuildContext context) {
-    Navigator.of(context).push(
+  Future<void> _navigateToAddBook(BuildContext context) async {
+    await Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) => const BookFormScreen(),
       ),
     );
   }
 
-  void _navigateToDetail(BuildContext context, String bookId) {
-    Navigator.of(context).push(
+  Future<void> _navigateToDetail(BuildContext context, String bookId) async {
+    await Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) => BookDetailScreen(bookId: bookId),
       ),

--- a/lib/widgets/book_card.dart
+++ b/lib/widgets/book_card.dart
@@ -1,0 +1,130 @@
+import 'package:book_manager/models/book.dart';
+import 'package:flutter/material.dart';
+
+/// 本のカードウィジェット
+class BookCard extends StatelessWidget {
+
+  const BookCard({
+    super.key,
+    required this.book,
+    this.onTap,
+  });
+  final Book book;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 表紙画像
+            Expanded(
+              flex: 3,
+              child: _buildCoverImage(),
+            ),
+            // 本の情報
+            Expanded(
+              flex: 2,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // タイトル
+                    Text(
+                      book.title,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    // 著者
+                    if (book.author.isNotEmpty)
+                      Text(
+                        book.author,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    const Spacer(),
+                    // ステータスチップ
+                    _StatusChip(status: book.status),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCoverImage() {
+    if (book.coverUrl != null && book.coverUrl!.isNotEmpty) {
+      return Image.network(
+        book.coverUrl!,
+        fit: BoxFit.cover,
+        width: double.infinity,
+        errorBuilder: (context, error, stackTrace) => _buildPlaceholder(),
+      );
+    }
+    return _buildPlaceholder();
+  }
+
+  Widget _buildPlaceholder() {
+    return Container(
+      color: Colors.grey[200],
+      child: Center(
+        child: Icon(
+          Icons.menu_book,
+          size: 48,
+          color: Colors.grey[400],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+
+  const _StatusChip({required this.status});
+  final ReadingStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: _getStatusColor().withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        status.displayName,
+        style: TextStyle(
+          fontSize: 10,
+          color: _getStatusColor(),
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
+  Color _getStatusColor() {
+    switch (status) {
+      case ReadingStatus.unread:
+        return Colors.grey;
+      case ReadingStatus.reading:
+        return Colors.blue;
+      case ReadingStatus.completed:
+        return Colors.green;
+    }
+  }
+}

--- a/lib/widgets/status_filter.dart
+++ b/lib/widgets/status_filter.dart
@@ -1,0 +1,74 @@
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/providers/books_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// ステータスフィルタータブ
+class StatusFilter extends ConsumerWidget {
+  const StatusFilter({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedStatus = ref.watch(selectedStatusFilterProvider);
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          _FilterChip(
+            label: '全て',
+            isSelected: selectedStatus == null,
+            onTap: () {
+              ref.read(selectedStatusFilterProvider.notifier).state = null;
+            },
+          ),
+          const SizedBox(width: 8),
+          ...ReadingStatus.values.map((status) {
+            return Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: _FilterChip(
+                label: status.displayName,
+                isSelected: selectedStatus == status,
+                onTap: () {
+                  ref.read(selectedStatusFilterProvider.notifier).state =
+                      status;
+                },
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+
+  const _FilterChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return FilterChip(
+      label: Text(label),
+      selected: isSelected,
+      onSelected: (_) => onTap(),
+      selectedColor: colorScheme.primaryContainer,
+      checkmarkColor: colorScheme.onPrimaryContainer,
+      labelStyle: TextStyle(
+        color: isSelected
+            ? colorScheme.onPrimaryContainer
+            : colorScheme.onSurface,
+      ),
+    );
+  }
+}

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -407,10 +407,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -644,10 +644,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -428,13 +428,29 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -528,6 +544,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+2"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -568,6 +624,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -601,7 +665,7 @@ packages:
     source: hosted
     version: "1.4.0"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
@@ -665,5 +729,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,11 @@ dependencies:
   flutter_hooks: ^0.20.5
   riverpod_annotation: ^2.6.1
 
+  # データベース・ユーティリティ
+  sqflite: ^2.4.2
+  path: ^1.9.0
+  uuid: ^4.5.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,34 +1,19 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:book_manager/main.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('App loads with home screen', (WidgetTester tester) async {
     await tester.pumpWidget(
       const ProviderScope(
-        child: MyApp(),
+        child: BookManagerApp(),
       ),
     );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // アプリタイトルが表示されることを確認
+    expect(find.text('読書管理'), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // 本を追加ボタンが表示されることを確認
+    expect(find.text('本を追加'), findsOneWidget);
   });
 }


### PR DESCRIPTION
 ## Summary      
  読書管理アプリのMVP機能一式を実装し、基盤となるアーキテクチャの構築からバグ修正までを含むブランチです。

  ## 主な変更内容

  ### MVP機能の実装
  - SQLiteを使用したローカルデータベース（`DatabaseHelper`）
  - 本のモデル（`Book`）、リポジトリ層（`BookRepository`）、状態管理（`BooksProvider`）
  - 画面: ホーム一覧（`HomeScreen`）、本の詳細（`BookDetailScreen`）、本の登録・編集フォーム（`BookFormScreen`）
  - ウィジェット: 本のカード表示（`BookCard`）、読書ステータスフィルター（`StatusFilter`）
  - 読書ステータス管理（未読・読書中・読了）

  ### Androidビルド環境の更新
  - Gradle 8.3 → 8.10.2
  - Android Gradle Plugin 8.1.0 → 8.7.2
  - Kotlin 1.8.22 → 1.9.22

  ### バグ修正
  - ホーム画面のナビゲーション関数の非同期処理を修正
  - ISBN入力のキーボードタイプを`text`に変更
  - カバー画像URL入力時にプレビューがリアルタイム反映されない問題を修正（`useListenable`追加）
  - `copyWith`でnullableフィールド（isbn, coverUrl, completedAt）をnullにクリアできない問題を修正（sentinelパターン導入）
  - 読了から他ステータスへ変更時に`completedAt`がクリアされない問題を修正

  ## アーキテクチャ
  lib/
  ├── database/       # SQLiteデータベースヘルパー
  ├── models/         # データモデル（Book）
  ├── providers/      # Riverpod状態管理
  ├── repositories/   # データアクセス層
  ├── screens/        # 画面（Home, BookDetail, BookForm）
  └── widgets/        # 共通ウィジェット（BookCard, StatusFilter）

  ## Test plan
  - [ ] 本の追加・編集・削除が正常に動作すること
  - [ ] 読書ステータス（未読・読書中・読了）の切り替えが正しく動作すること
  - [ ] 読了→未読/読書中への変更時にcompletedAtがクリアされること
  - [ ] カバー画像URLを入力するとプレビューがリアルタイムで表示されること
  - [ ] ISBN/カバーURL/completedAtをクリア（null化）できること
  - [ ] ステータスフィルターで一覧が正しく絞り込まれること
  - [ ] Androidビルドが正常に完了すること