### PR TITLE
Google Books APIによる書籍検索・自動入力機能を追加

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="book_manager"
         android:name="${applicationName}"

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.7.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -97,7 +97,6 @@
 				4994C5EC0C937994D5E42F10 /* Pods-RunnerTests.release.xcconfig */,
 				AC2BF2C80E73DF58AEBF9FF9 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -278,9 +277,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -473,6 +476,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -655,6 +659,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -677,6 +682,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/lib/models/book_search_result.dart
+++ b/lib/models/book_search_result.dart
@@ -1,0 +1,66 @@
+/// 書籍検索結果のモデル
+class BookSearchResult {
+  const BookSearchResult({
+    required this.title,
+    required this.authors,
+    this.isbn,
+    this.coverUrl,
+  });
+
+  /// Google Books APIのレスポンスから生成
+  factory BookSearchResult.fromGoogleBooksJson(Map<String, dynamic> json) {
+    final volumeInfo = json['volumeInfo'] as Map<String, dynamic>? ?? {};
+
+    // タイトル
+    final title = volumeInfo['title'] as String? ?? '';
+
+    // 著者（リストをカンマ区切りで結合）
+    final authorsList = volumeInfo['authors'] as List<dynamic>?;
+    final authors = authorsList?.map((a) => a as String).join(', ') ?? '';
+
+    // ISBN（ISBN-13を優先、なければISBN-10）
+    String? isbn;
+    final identifiers =
+        volumeInfo['industryIdentifiers'] as List<dynamic>? ?? [];
+    for (final id in identifiers) {
+      final idMap = id as Map<String, dynamic>;
+      if (idMap['type'] == 'ISBN_13') {
+        isbn = idMap['identifier'] as String?;
+        break;
+      }
+    }
+    if (isbn == null) {
+      for (final id in identifiers) {
+        final idMap = id as Map<String, dynamic>;
+        if (idMap['type'] == 'ISBN_10') {
+          isbn = idMap['identifier'] as String?;
+          break;
+        }
+      }
+    }
+
+    // 表紙画像URL（http → https変換）
+    String? coverUrl;
+    final imageLinks =
+        volumeInfo['imageLinks'] as Map<String, dynamic>?;
+    if (imageLinks != null) {
+      final thumbnail = imageLinks['thumbnail'] as String? ??
+          imageLinks['smallThumbnail'] as String?;
+      if (thumbnail != null) {
+        coverUrl = thumbnail.replaceFirst('http://', 'https://');
+      }
+    }
+
+    return BookSearchResult(
+      title: title,
+      authors: authors,
+      isbn: isbn,
+      coverUrl: coverUrl,
+    );
+  }
+
+  final String title;
+  final String authors;
+  final String? isbn;
+  final String? coverUrl;
+}

--- a/lib/providers/book_search_provider.dart
+++ b/lib/providers/book_search_provider.dart
@@ -1,0 +1,36 @@
+import 'package:book_manager/models/book_search_result.dart';
+import 'package:book_manager/services/book_search_service.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// BookSearchServiceのプロバイダー
+final bookSearchServiceProvider = Provider<BookSearchService>((ref) {
+  return BookSearchService();
+});
+
+/// 書籍検索の状態を管理するNotifier
+class BookSearchNotifier extends AsyncNotifier<List<BookSearchResult>> {
+  @override
+  Future<List<BookSearchResult>> build() async {
+    return [];
+  }
+
+  /// 書籍を検索
+  Future<void> search(String query) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final service = ref.read(bookSearchServiceProvider);
+      return await service.search(query);
+    });
+  }
+
+  /// 検索結果をクリア
+  void clear() {
+    state = const AsyncValue.data([]);
+  }
+}
+
+/// 書籍検索のプロバイダー
+final bookSearchProvider =
+    AsyncNotifierProvider<BookSearchNotifier, List<BookSearchResult>>(() {
+  return BookSearchNotifier();
+});

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -1,5 +1,6 @@
 import 'package:book_manager/models/book.dart';
 import 'package:book_manager/providers/books_provider.dart';
+import 'package:book_manager/widgets/book_search_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -32,6 +33,26 @@ class BookFormScreen extends HookConsumerWidget {
       appBar: AppBar(
         title: Text(isEditing ? '本を編集' : '本を追加'),
         centerTitle: true,
+        actions: [
+          if (!isEditing)
+            IconButton(
+              icon: const Icon(Icons.search),
+              tooltip: '書籍を検索',
+              onPressed: () async {
+                final result = await showBookSearchDialog(context);
+                if (result != null) {
+                  titleController.text = result.title;
+                  authorController.text = result.authors;
+                  if (result.isbn != null) {
+                    isbnController.text = result.isbn!;
+                  }
+                  if (result.coverUrl != null) {
+                    coverUrlController.text = result.coverUrl!;
+                  }
+                }
+              },
+            ),
+        ],
       ),
       body: Form(
         key: formKey,

--- a/lib/services/book_search_service.dart
+++ b/lib/services/book_search_service.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:book_manager/models/book_search_result.dart';
+import 'package:http/http.dart' as http;
+
+/// Google Books APIを使った書籍検索サービス
+class BookSearchService {
+  BookSearchService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  static const _baseUrl = 'https://www.googleapis.com/books/v1/volumes';
+
+  /// クエリで書籍を検索
+  ///
+  /// 数字のみ10桁または13桁の場合はISBN検索、それ以外はタイトル検索を行う。
+  Future<List<BookSearchResult>> search(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return [];
+
+    // 数字のみ10桁or13桁ならISBN検索
+    final isIsbn = RegExp(r'^\d{10}(\d{3})?$').hasMatch(trimmed);
+    final searchQuery = isIsbn ? 'isbn:$trimmed' : 'intitle:$trimmed';
+
+    final uri = Uri.parse(_baseUrl).replace(queryParameters: {
+      'q': searchQuery,
+      'maxResults': '20',
+    });
+
+    final response = await _client.get(uri);
+
+    if (response.statusCode != 200) {
+      throw Exception('書籍の検索に失敗しました (${response.statusCode})');
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final items = json['items'] as List<dynamic>?;
+
+    if (items == null) return [];
+
+    return items
+        .map((item) => BookSearchResult.fromGoogleBooksJson(
+            item as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/widgets/book_search_dialog.dart
+++ b/lib/widgets/book_search_dialog.dart
@@ -1,0 +1,193 @@
+import 'package:book_manager/models/book_search_result.dart';
+import 'package:book_manager/providers/book_search_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 書籍検索ボトムシートを表示し、選択結果を返す
+Future<BookSearchResult?> showBookSearchDialog(BuildContext context) {
+  return showModalBottomSheet<BookSearchResult>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (context) => DraggableScrollableSheet(
+      initialChildSize: 0.85,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (context, scrollController) => _BookSearchSheet(
+        scrollController: scrollController,
+      ),
+    ),
+  );
+}
+
+class _BookSearchSheet extends HookConsumerWidget {
+  const _BookSearchSheet({required this.scrollController});
+
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchController = useTextEditingController();
+    final searchResults = ref.watch(bookSearchProvider);
+
+    return Column(
+      children: [
+        // ドラッグハンドル
+        Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: Colors.grey[400],
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+        ),
+
+        // タイトル
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            '書籍を検索',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+        ),
+
+        // 検索バー
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: TextField(
+            controller: searchController,
+            decoration: InputDecoration(
+              hintText: 'ISBNまたはタイトルで検索',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () {
+                  searchController.clear();
+                  ref.read(bookSearchProvider.notifier).clear();
+                },
+              ),
+              border: const OutlineInputBorder(),
+            ),
+            textInputAction: TextInputAction.search,
+            onSubmitted: (value) async {
+              if (value.trim().isNotEmpty) {
+                await ref.read(bookSearchProvider.notifier).search(value);
+              }
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        // 検索結果
+        Expanded(
+          child: searchResults.when(
+            data: (results) {
+              if (results.isEmpty) {
+                return Center(
+                  child: Text(
+                    searchController.text.isEmpty
+                        ? 'ISBNまたはタイトルを入力して検索'
+                        : '検索結果がありません',
+                    style: TextStyle(color: Colors.grey[600]),
+                  ),
+                );
+              }
+              return ListView.separated(
+                controller: scrollController,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: results.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (context, index) {
+                  final result = results[index];
+                  return _SearchResultTile(
+                    result: result,
+                    onTap: () {
+                      ref.read(bookSearchProvider.notifier).clear();
+                      Navigator.of(context).pop(result);
+                    },
+                  );
+                },
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  '検索エラー: $error',
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SearchResultTile extends StatelessWidget {
+  const _SearchResultTile({
+    required this.result,
+    required this.onTap,
+  });
+
+  final BookSearchResult result;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(vertical: 8),
+      leading: SizedBox(
+        width: 48,
+        child: result.coverUrl != null
+            ? Image.network(
+                result.coverUrl!,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => const Icon(
+                  Icons.book,
+                  size: 32,
+                  color: Colors.grey,
+                ),
+              )
+            : const Icon(Icons.book, size: 32, color: Colors.grey),
+      ),
+      title: Text(
+        result.title,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (result.authors.isNotEmpty)
+            Text(
+              result.authors,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(color: Colors.grey[700]),
+            ),
+          if (result.isbn != null)
+            Text(
+              'ISBN: ${result.isbn}',
+              style: TextStyle(
+                color: Colors.grey[500],
+                fontSize: 12,
+              ),
+            ),
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -300,7 +300,7 @@ packages:
     source: hosted
     version: "2.6.1"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
@@ -730,4 +730,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,9 @@ dependencies:
   flutter_hooks: ^0.21.3+1
   riverpod_annotation: ^2.6.1
 
+  # HTTP通信
+  http: ^1.2.0
+
   # データベース・ユーティリティ
   sqflite: ^2.4.2
   path: ^1.9.0


### PR DESCRIPTION
## 概要

- Google Books APIを使った書籍検索機能を追加し、書籍追加フォームへの自動入力を実現
- ISBNまたはタイトルで検索可能で、検索結果からタイトル・著者・ISBN・表紙画像URLが自動入力される

## 変更内容

### 新規ファイル
- **`lib/models/book_search_result.dart`** — 検索結果モデル（ISBN-13優先、http→https変換対応）
- **`lib/services/book_search_service.dart`** — Google Books API呼び出しサービス（ISBN/タイトル自動判定、`http.Client`注入でテスタビリティ確保）
- **`lib/providers/book_search_provider.dart`** — `BookSearchNotifier`による検索状態管理
- **`lib/widgets/book_search_dialog.dart`** — ボトムシート形式の検索UI（サムネイル・タイトル・著者・ISBN表示）

### 修正ファイル
- **`pubspec.yaml`** — `http: ^1.2.0` 追加
- **`lib/screens/book_form_screen.dart`** — AppBarに検索アイコン追加（新規追加時のみ表示）、選択結果でフォーム自動入力
- **`android/app/src/main/AndroidManifest.xml`** — `INTERNET` 権限追加
- **`android/settings.gradle`** — Kotlin 1.9.22 → 2.1.0 にアップグレード（Flutterサポート要件対応）

## UXフロー
1. 「本を追加」画面 → AppBar右の🔍アイコンをタップ
2. ボトムシートでISBNまたはタイトルを入力 → 検索実行
3. 結果一覧から選択 → フォームに自動入力（タイトル・著者・ISBN・表紙URL）
4. 必要に応じて手動修正 → 保存

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他

## テスト

- [ ] `flutter pub get` → `flutter analyze` でエラーなし
- [ ] 「本を追加」画面でAppBarに検索アイコンが表示される
- [ ] 「本を編集」画面では検索アイコンが表示されない
- [ ] ISBNで検索（例: `9784873115658`）→ 結果が表示される
- [ ] タイトルで検索（例: `リーダブルコード`）→ 結果が表示される
- [ ] 結果タップ → フォームに自動入力され、表紙プレビューが表示される
- [ ] 空文字での検索 → 検索が実行されない
- [ ] ネットワークエラー時 → エラーメッセージが表示される
- [ ] Androidビルドが警告なく成功する（Kotlinアップグレード確認）

## 関連Issue

#7