### PR TITLE
読書日付の管理機能を追加（読書開始日・読了日・再読記録）

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -34,6 +34,9 @@ class DatabaseHelper {
       version: _databaseVersion,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
+      onConfigure: (db) async {
+        await db.execute('PRAGMA foreign_keys = ON');
+      },
     );
   }
 

--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -11,9 +11,10 @@ class DatabaseHelper {
 
   DatabaseHelper._internal();
   static const _databaseName = 'book_manager.db';
-  static const _databaseVersion = 1;
+  static const _databaseVersion = 2;
 
   static const tableName = 'books';
+  static const readingHistoriesTable = 'reading_histories';
 
   // シングルトンインスタンス
   static DatabaseHelper? _instance;
@@ -32,6 +33,7 @@ class DatabaseHelper {
       path,
       version: _databaseVersion,
       onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
     );
   }
 
@@ -45,9 +47,36 @@ class DatabaseHelper {
         cover_url TEXT,
         status INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
+        started_at INTEGER,
         completed_at INTEGER
       )
     ''');
+    await db.execute('''
+      CREATE TABLE $readingHistoriesTable (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        book_id TEXT NOT NULL,
+        started_at INTEGER,
+        completed_at INTEGER,
+        FOREIGN KEY (book_id) REFERENCES $tableName (id)
+      )
+    ''');
+  }
+
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute(
+        'ALTER TABLE $tableName ADD COLUMN started_at INTEGER',
+      );
+      await db.execute('''
+        CREATE TABLE $readingHistoriesTable (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          book_id TEXT NOT NULL,
+          started_at INTEGER,
+          completed_at INTEGER,
+          FOREIGN KEY (book_id) REFERENCES $tableName (id)
+        )
+      ''');
+    }
   }
 
   /// 本を挿入
@@ -106,6 +135,35 @@ class DatabaseHelper {
       tableName,
       where: 'id = ?',
       whereArgs: [id],
+    );
+  }
+
+  /// 読書履歴を挿入
+  Future<int> insertHistory(Map<String, dynamic> row) async {
+    final db = await database;
+    return await db.insert(readingHistoriesTable, row);
+  }
+
+  /// 本IDで読書履歴を取得
+  Future<List<Map<String, dynamic>>> queryHistoriesByBookId(
+    String bookId,
+  ) async {
+    final db = await database;
+    return await db.query(
+      readingHistoriesTable,
+      where: 'book_id = ?',
+      whereArgs: [bookId],
+      orderBy: 'id ASC',
+    );
+  }
+
+  /// 本IDで読書履歴を削除
+  Future<int> deleteHistoriesByBookId(String bookId) async {
+    final db = await database;
+    return await db.delete(
+      readingHistoriesTable,
+      where: 'book_id = ?',
+      whereArgs: [bookId],
     );
   }
 }

--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -57,7 +57,7 @@ class DatabaseHelper {
         book_id TEXT NOT NULL,
         started_at INTEGER,
         completed_at INTEGER,
-        FOREIGN KEY (book_id) REFERENCES $tableName (id)
+        FOREIGN KEY (book_id) REFERENCES $tableName (id) ON DELETE CASCADE
       )
     ''');
   }
@@ -73,7 +73,7 @@ class DatabaseHelper {
           book_id TEXT NOT NULL,
           started_at INTEGER,
           completed_at INTEGER,
-          FOREIGN KEY (book_id) REFERENCES $tableName (id)
+          FOREIGN KEY (book_id) REFERENCES $tableName (id) ON DELETE CASCADE
         )
       ''');
     }

--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -57,6 +57,7 @@ class Book {
     this.coverUrl,
     required this.status,
     required this.createdAt,
+    this.startedAt,
     this.completedAt,
   });
 
@@ -70,6 +71,9 @@ class Book {
       coverUrl: map['cover_url'] as String?,
       status: ReadingStatusExtension.fromValue(map['status'] as int),
       createdAt: DateTime.fromMillisecondsSinceEpoch(map['created_at'] as int),
+      startedAt: map['started_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['started_at'] as int)
+          : null,
       completedAt: map['completed_at'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['completed_at'] as int)
           : null,
@@ -82,6 +86,7 @@ class Book {
   final String? coverUrl;
   final ReadingStatus status;
   final DateTime createdAt;
+  final DateTime? startedAt;
   final DateTime? completedAt;
 
   /// データベース用のMapに変換
@@ -94,6 +99,7 @@ class Book {
       'cover_url': coverUrl,
       'status': status.value,
       'created_at': createdAt.millisecondsSinceEpoch,
+      'started_at': startedAt?.millisecondsSinceEpoch,
       'completed_at': completedAt?.millisecondsSinceEpoch,
     };
   }
@@ -110,6 +116,7 @@ class Book {
     Object? coverUrl = _sentinel,
     ReadingStatus? status,
     DateTime? createdAt,
+    Object? startedAt = _sentinel,
     Object? completedAt = _sentinel,
   }) {
     return Book(
@@ -120,6 +127,9 @@ class Book {
       coverUrl: coverUrl == _sentinel ? this.coverUrl : coverUrl as String?,
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,
+      startedAt: startedAt == _sentinel
+          ? this.startedAt
+          : startedAt as DateTime?,
       completedAt: completedAt == _sentinel
           ? this.completedAt
           : completedAt as DateTime?,

--- a/lib/models/reading_history.dart
+++ b/lib/models/reading_history.dart
@@ -1,0 +1,70 @@
+/// copyWithでnullableフィールドをnullにクリアするためのsentinel値
+const _sentinel = Object();
+
+/// 読書履歴モデル
+class ReadingHistory {
+
+  const ReadingHistory({
+    required this.id,
+    required this.bookId,
+    this.startedAt,
+    this.completedAt,
+  });
+
+  /// Mapから読書履歴を作成
+  factory ReadingHistory.fromMap(Map<String, dynamic> map) {
+    return ReadingHistory(
+      id: map['id'] as int,
+      bookId: map['book_id'] as String,
+      startedAt: map['started_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['started_at'] as int)
+          : null,
+      completedAt: map['completed_at'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['completed_at'] as int)
+          : null,
+    );
+  }
+
+  final int id;
+  final String bookId;
+  final DateTime? startedAt;
+  final DateTime? completedAt;
+
+  /// データベース用のMapに変換
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'book_id': bookId,
+      'started_at': startedAt?.millisecondsSinceEpoch,
+      'completed_at': completedAt?.millisecondsSinceEpoch,
+    };
+  }
+
+  /// 挿入用のMap（idを除く）
+  Map<String, dynamic> toInsertMap() {
+    return {
+      'book_id': bookId,
+      'started_at': startedAt?.millisecondsSinceEpoch,
+      'completed_at': completedAt?.millisecondsSinceEpoch,
+    };
+  }
+
+  /// コピーを作成（一部のフィールドを変更）
+  ReadingHistory copyWith({
+    int? id,
+    String? bookId,
+    Object? startedAt = _sentinel,
+    Object? completedAt = _sentinel,
+  }) {
+    return ReadingHistory(
+      id: id ?? this.id,
+      bookId: bookId ?? this.bookId,
+      startedAt: startedAt == _sentinel
+          ? this.startedAt
+          : startedAt as DateTime?,
+      completedAt: completedAt == _sentinel
+          ? this.completedAt
+          : completedAt as DateTime?,
+    );
+  }
+}

--- a/lib/models/reading_history.dart
+++ b/lib/models/reading_history.dart
@@ -40,15 +40,6 @@ class ReadingHistory {
     };
   }
 
-  /// 挿入用のMap（idを除く）
-  Map<String, dynamic> toInsertMap() {
-    return {
-      'book_id': bookId,
-      'started_at': startedAt?.millisecondsSinceEpoch,
-      'completed_at': completedAt?.millisecondsSinceEpoch,
-    };
-  }
-
   /// コピーを作成（一部のフィールドを変更）
   ReadingHistory copyWith({
     int? id,

--- a/lib/providers/books_provider.dart
+++ b/lib/providers/books_provider.dart
@@ -1,10 +1,18 @@
 import 'package:book_manager/models/book.dart';
+import 'package:book_manager/models/reading_history.dart';
 import 'package:book_manager/repositories/book_repository.dart';
+import 'package:book_manager/repositories/reading_history_repository.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// リポジトリのプロバイダー
 final bookRepositoryProvider = Provider<BookRepository>((ref) {
   return BookRepository();
+});
+
+/// 読書履歴リポジトリのプロバイダー
+final readingHistoryRepositoryProvider =
+    Provider<ReadingHistoryRepository>((ref) {
+  return ReadingHistoryRepository();
 });
 
 /// 選択中のフィルターステータス（nullは全て）
@@ -31,6 +39,8 @@ class BooksNotifier extends AsyncNotifier<List<Book>> {
     String? isbn,
     String? coverUrl,
     ReadingStatus status = ReadingStatus.unread,
+    DateTime? startedAt,
+    DateTime? completedAt,
   }) async {
     final repository = ref.read(bookRepositoryProvider);
     await repository.addBook(
@@ -39,6 +49,8 @@ class BooksNotifier extends AsyncNotifier<List<Book>> {
       isbn: isbn,
       coverUrl: coverUrl,
       status: status,
+      startedAt: startedAt,
+      completedAt: completedAt,
     );
     ref.invalidateSelf();
   }
@@ -60,9 +72,34 @@ class BooksNotifier extends AsyncNotifier<List<Book>> {
     }
   }
 
-  /// 本を削除
+  /// もう一度読む（再読）
+  Future<void> reReadBook(String bookId) async {
+    final repository = ref.read(bookRepositoryProvider);
+    final historyRepository = ref.read(readingHistoryRepositoryProvider);
+    final book = await repository.getBookById(bookId);
+    if (book != null) {
+      // 現在の読書記録を履歴に保存
+      await historyRepository.addHistory(
+        bookId: bookId,
+        startedAt: book.startedAt,
+        completedAt: book.completedAt,
+      );
+      // ステータスを読書中に変更、日付をリセット
+      final updatedBook = book.copyWith(
+        status: ReadingStatus.reading,
+        startedAt: DateTime.now(),
+        completedAt: null,
+      );
+      await repository.updateBook(updatedBook);
+      ref.invalidateSelf();
+    }
+  }
+
+  /// 本を削除（関連履歴も削除）
   Future<void> deleteBook(String id) async {
     final repository = ref.read(bookRepositoryProvider);
+    final historyRepository = ref.read(readingHistoryRepositoryProvider);
+    await historyRepository.deleteHistoriesByBookId(id);
     await repository.deleteBook(id);
     ref.invalidateSelf();
   }
@@ -90,4 +127,11 @@ final filteredBooksProvider = Provider<AsyncValue<List<Book>>>((ref) {
 final bookByIdProvider = FutureProvider.family<Book?, String>((ref, id) async {
   final repository = ref.read(bookRepositoryProvider);
   return await repository.getBookById(id);
+});
+
+/// 特定の本の読書履歴を取得するプロバイダー
+final readingHistoriesProvider =
+    FutureProvider.family<List<ReadingHistory>, String>((ref, bookId) async {
+  final repository = ref.read(readingHistoryRepositoryProvider);
+  return await repository.getHistoriesByBookId(bookId);
 });

--- a/lib/repositories/book_repository.dart
+++ b/lib/repositories/book_repository.dart
@@ -20,7 +20,21 @@ class BookRepository {
     String? isbn,
     String? coverUrl,
     ReadingStatus status = ReadingStatus.unread,
+    DateTime? startedAt,
+    DateTime? completedAt,
   }) async {
+    final now = DateTime.now();
+
+    // ステータスに応じて日付を自動設定（明示的に渡されていない場合）
+    DateTime? effectiveStartedAt = startedAt;
+    DateTime? effectiveCompletedAt = completedAt;
+    if (status == ReadingStatus.reading) {
+      effectiveStartedAt ??= now;
+    } else if (status == ReadingStatus.completed) {
+      effectiveStartedAt ??= now;
+      effectiveCompletedAt ??= now;
+    }
+
     final book = Book(
       id: _uuid.v4(),
       title: title,
@@ -28,7 +42,9 @@ class BookRepository {
       isbn: isbn,
       coverUrl: coverUrl,
       status: status,
-      createdAt: DateTime.now(),
+      createdAt: now,
+      startedAt: effectiveStartedAt,
+      completedAt: effectiveCompletedAt,
     );
 
     await _dbHelper.insert(book.toMap());
@@ -55,16 +71,26 @@ class BookRepository {
 
   /// 本を更新
   Future<Book> updateBook(Book book) async {
-    final Book updatedBook;
+    Book updatedBook = book;
+
+    // reading に変更 → startedAt が null なら自動設定
+    if (book.status == ReadingStatus.reading && book.startedAt == null) {
+      updatedBook = updatedBook.copyWith(startedAt: DateTime.now());
+    }
+
+    // completed に変更 → completedAt が null なら自動設定
     if (book.status == ReadingStatus.completed && book.completedAt == null) {
-      // 読了ステータスに変更された場合、completedAtを設定
-      updatedBook = book.copyWith(completedAt: DateTime.now());
-    } else if (book.status != ReadingStatus.completed &&
-        book.completedAt != null) {
-      // 読了以外に変更された場合、completedAtをクリア
-      updatedBook = book.copyWith(completedAt: null);
-    } else {
-      updatedBook = book;
+      updatedBook = updatedBook.copyWith(completedAt: DateTime.now());
+    }
+
+    // completed 以外に変更 → completedAt クリア
+    if (book.status != ReadingStatus.completed && book.completedAt != null) {
+      updatedBook = updatedBook.copyWith(completedAt: null);
+    }
+
+    // unread に変更 → startedAt もクリア
+    if (book.status == ReadingStatus.unread && book.startedAt != null) {
+      updatedBook = updatedBook.copyWith(startedAt: null);
     }
 
     await _dbHelper.update(updatedBook.toMap());

--- a/lib/repositories/book_repository.dart
+++ b/lib/repositories/book_repository.dart
@@ -72,19 +72,20 @@ class BookRepository {
   /// 本を更新
   Future<Book> updateBook(Book book) async {
     Book updatedBook = book;
+    final now = DateTime.now();
 
     // reading に変更 → startedAt が null なら自動設定
     if (book.status == ReadingStatus.reading && book.startedAt == null) {
-      updatedBook = updatedBook.copyWith(startedAt: DateTime.now());
+      updatedBook = updatedBook.copyWith(startedAt: now);
     }
 
     // completed に変更 → startedAt/completedAt が null なら自動設定
     if (book.status == ReadingStatus.completed) {
       if (updatedBook.startedAt == null) {
-        updatedBook = updatedBook.copyWith(startedAt: DateTime.now());
+        updatedBook = updatedBook.copyWith(startedAt: now);
       }
       if (updatedBook.completedAt == null) {
-        updatedBook = updatedBook.copyWith(completedAt: DateTime.now());
+        updatedBook = updatedBook.copyWith(completedAt: now);
       }
     }
 

--- a/lib/repositories/book_repository.dart
+++ b/lib/repositories/book_repository.dart
@@ -78,9 +78,14 @@ class BookRepository {
       updatedBook = updatedBook.copyWith(startedAt: DateTime.now());
     }
 
-    // completed に変更 → completedAt が null なら自動設定
-    if (book.status == ReadingStatus.completed && book.completedAt == null) {
-      updatedBook = updatedBook.copyWith(completedAt: DateTime.now());
+    // completed に変更 → startedAt/completedAt が null なら自動設定
+    if (book.status == ReadingStatus.completed) {
+      if (updatedBook.startedAt == null) {
+        updatedBook = updatedBook.copyWith(startedAt: DateTime.now());
+      }
+      if (updatedBook.completedAt == null) {
+        updatedBook = updatedBook.copyWith(completedAt: DateTime.now());
+      }
     }
 
     // completed 以外に変更 → completedAt クリア

--- a/lib/repositories/reading_history_repository.dart
+++ b/lib/repositories/reading_history_repository.dart
@@ -1,0 +1,42 @@
+import 'package:book_manager/database/database_helper.dart';
+import 'package:book_manager/models/reading_history.dart';
+
+/// 読書履歴のリポジトリ（データアクセス層）
+class ReadingHistoryRepository {
+
+  ReadingHistoryRepository({
+    DatabaseHelper? dbHelper,
+  }) : _dbHelper = dbHelper ?? DatabaseHelper();
+  final DatabaseHelper _dbHelper;
+
+  /// 読書履歴を追加
+  Future<ReadingHistory> addHistory({
+    required String bookId,
+    DateTime? startedAt,
+    DateTime? completedAt,
+  }) async {
+    final map = {
+      'book_id': bookId,
+      'started_at': startedAt?.millisecondsSinceEpoch,
+      'completed_at': completedAt?.millisecondsSinceEpoch,
+    };
+    final id = await _dbHelper.insertHistory(map);
+    return ReadingHistory(
+      id: id,
+      bookId: bookId,
+      startedAt: startedAt,
+      completedAt: completedAt,
+    );
+  }
+
+  /// 本IDで読書履歴を取得
+  Future<List<ReadingHistory>> getHistoriesByBookId(String bookId) async {
+    final maps = await _dbHelper.queryHistoriesByBookId(bookId);
+    return maps.map((map) => ReadingHistory.fromMap(map)).toList();
+  }
+
+  /// 本IDで読書履歴を削除
+  Future<void> deleteHistoriesByBookId(String bookId) async {
+    await _dbHelper.deleteHistoriesByBookId(bookId);
+  }
+}

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -216,8 +216,6 @@ class BookDetailScreen extends ConsumerWidget {
                 book.status == ReadingStatus.completed)
               _buildEditableDateRow(
                 context,
-                ref,
-                book,
                 '読書開始日',
                 book.startedAt,
                 (date) async {
@@ -229,8 +227,6 @@ class BookDetailScreen extends ConsumerWidget {
             if (book.status == ReadingStatus.completed)
               _buildEditableDateRow(
                 context,
-                ref,
-                book,
                 '読了日',
                 book.completedAt,
                 (date) async {
@@ -273,8 +269,6 @@ class BookDetailScreen extends ConsumerWidget {
 
   Widget _buildEditableDateRow(
     BuildContext context,
-    WidgetRef ref,
-    Book book,
     String label,
     DateTime? date,
     Future<void> Function(DateTime) onDateChanged,
@@ -334,7 +328,8 @@ class BookDetailScreen extends ConsumerWidget {
     Book book,
   ) {
     final historiesAsync = ref.watch(readingHistoriesProvider(bookId));
-    final hasCurrentSession = book.startedAt != null;
+    final hasCurrentSession =
+        book.startedAt != null || book.completedAt != null;
 
     return historiesAsync.when(
       data: (histories) {
@@ -379,8 +374,37 @@ class BookDetailScreen extends ConsumerWidget {
           ),
         );
       },
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
+      loading: () => const Center(
+        child: CircularProgressIndicator(),
+      ),
+      error: (error, stackTrace) {
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '読書履歴を読み込めませんでした',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () {
+                      ref.invalidate(readingHistoriesProvider(bookId));
+                    },
+                    child: const Text('再試行'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -223,7 +223,6 @@ class BookDetailScreen extends ConsumerWidget {
                   await ref.read(booksProvider.notifier).updateBook(updatedBook);
                   ref.invalidate(bookByIdProvider(bookId));
                 },
-                allowFutureDate: true,
               ),
             if (book.status == ReadingStatus.completed)
               _buildEditableDateRow(
@@ -272,9 +271,7 @@ class BookDetailScreen extends ConsumerWidget {
     BuildContext context,
     String label,
     DateTime? date,
-    Future<void> Function(DateTime) onDateChanged, {
-    bool allowFutureDate = false,
-  }
+    Future<void> Function(DateTime) onDateChanged,
   ) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -299,13 +296,11 @@ class BookDetailScreen extends ConsumerWidget {
           ),
           IconButton(
             onPressed: () async {
-              final lastDate =
-                  allowFutureDate ? DateTime(2100) : DateTime.now();
               final picked = await showDatePicker(
                 context: context,
                 initialDate: date ?? DateTime.now(),
                 firstDate: DateTime(2000),
-                lastDate: lastDate,
+                lastDate: DateTime.now(),
               );
               if (picked != null) {
                 await onDateChanged(picked);

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:book_manager/models/book.dart';
 import 'package:book_manager/providers/books_provider.dart';
 import 'package:book_manager/screens/book_form_screen.dart';
+import 'package:book_manager/utils/date_formatter.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -209,28 +210,29 @@ class BookDetailScreen extends ConsumerWidget {
             _buildInfoRow(
               context,
               '登録日',
-              _formatDate(book.createdAt),
+              formatDate(book.createdAt),
             ),
-            if (book.startedAt != null)
+            if (book.status == ReadingStatus.reading ||
+                book.status == ReadingStatus.completed)
               _buildEditableDateRow(
                 context,
                 ref,
                 book,
                 '読書開始日',
-                book.startedAt!,
+                book.startedAt,
                 (date) async {
                   final updatedBook = book.copyWith(startedAt: date);
                   await ref.read(booksProvider.notifier).updateBook(updatedBook);
                   ref.invalidate(bookByIdProvider(bookId));
                 },
               ),
-            if (book.completedAt != null)
+            if (book.status == ReadingStatus.completed)
               _buildEditableDateRow(
                 context,
                 ref,
                 book,
                 '読了日',
-                book.completedAt!,
+                book.completedAt,
                 (date) async {
                   final updatedBook = book.copyWith(completedAt: date);
                   await ref.read(booksProvider.notifier).updateBook(updatedBook);
@@ -274,13 +276,12 @@ class BookDetailScreen extends ConsumerWidget {
     WidgetRef ref,
     Book book,
     String label,
-    DateTime date,
+    DateTime? date,
     Future<void> Function(DateTime) onDateChanged,
   ) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
             width: 100,
@@ -293,15 +294,17 @@ class BookDetailScreen extends ConsumerWidget {
           ),
           Expanded(
             child: Text(
-              _formatDate(date),
-              style: Theme.of(context).textTheme.bodyMedium,
+              date != null ? formatDate(date) : '未設定',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: date == null ? Colors.grey : null,
+                  ),
             ),
           ),
-          InkWell(
-            onTap: () async {
+          IconButton(
+            onPressed: () async {
               final picked = await showDatePicker(
                 context: context,
-                initialDate: date,
+                initialDate: date ?? DateTime.now(),
                 firstDate: DateTime(2000),
                 lastDate: DateTime.now(),
               );
@@ -309,10 +312,15 @@ class BookDetailScreen extends ConsumerWidget {
                 await onDateChanged(picked);
               }
             },
-            child: Icon(
+            icon: Icon(
               Icons.edit_calendar,
               size: 20,
               color: Theme.of(context).colorScheme.primary,
+            ),
+            tooltip: '$labelを編集',
+            constraints: const BoxConstraints(
+              minWidth: 40,
+              minHeight: 40,
             ),
           ),
         ],
@@ -384,9 +392,9 @@ class BookDetailScreen extends ConsumerWidget {
     bool isCurrent = false,
   }) {
     final startStr =
-        startedAt != null ? _formatDate(startedAt) : '不明';
+        startedAt != null ? formatDate(startedAt) : '不明';
     final endStr = completedAt != null
-        ? _formatDate(completedAt)
+        ? formatDate(completedAt)
         : '読書中';
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -397,10 +405,6 @@ class BookDetailScreen extends ConsumerWidget {
             ),
       ),
     );
-  }
-
-  String _formatDate(DateTime date) {
-    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
   }
 
   Future<void> _updateStatus(

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -131,10 +131,28 @@ class BookDetailScreen extends ConsumerWidget {
                     await _updateStatus(ref, book.id, newSelection.first);
                   },
                 ),
+                const SizedBox(height: 16),
+
+                // もう一度読むボタン（completedステータス時のみ）
+                if (book.status == ReadingStatus.completed)
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: () =>
+                          _showReReadDialog(context, ref, book),
+                      icon: const Icon(Icons.replay),
+                      label: const Text('もう一度読む'),
+                    ),
+                  ),
                 const SizedBox(height: 24),
 
                 // 詳細情報
-                _buildInfoSection(context, book),
+                _buildInfoSection(context, ref, book),
+
+                const SizedBox(height: 16),
+
+                // 読書履歴セクション
+                _buildHistorySection(context, ref, book),
               ],
             ),
           ),
@@ -173,7 +191,7 @@ class BookDetailScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildInfoSection(BuildContext context, Book book) {
+  Widget _buildInfoSection(BuildContext context, WidgetRef ref, Book book) {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -193,11 +211,31 @@ class BookDetailScreen extends ConsumerWidget {
               '登録日',
               _formatDate(book.createdAt),
             ),
-            if (book.completedAt != null)
-              _buildInfoRow(
+            if (book.startedAt != null)
+              _buildEditableDateRow(
                 context,
+                ref,
+                book,
+                '読書開始日',
+                book.startedAt!,
+                (date) async {
+                  final updatedBook = book.copyWith(startedAt: date);
+                  await ref.read(booksProvider.notifier).updateBook(updatedBook);
+                  ref.invalidate(bookByIdProvider(bookId));
+                },
+              ),
+            if (book.completedAt != null)
+              _buildEditableDateRow(
+                context,
+                ref,
+                book,
                 '読了日',
-                _formatDate(book.completedAt!),
+                book.completedAt!,
+                (date) async {
+                  final updatedBook = book.copyWith(completedAt: date);
+                  await ref.read(booksProvider.notifier).updateBook(updatedBook);
+                  ref.invalidate(bookByIdProvider(bookId));
+                },
               ),
           ],
         ),
@@ -212,7 +250,7 @@ class BookDetailScreen extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
-            width: 80,
+            width: 100,
             child: Text(
               label,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
@@ -227,6 +265,136 @@ class BookDetailScreen extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildEditableDateRow(
+    BuildContext context,
+    WidgetRef ref,
+    Book book,
+    String label,
+    DateTime date,
+    Future<void> Function(DateTime) onDateChanged,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              _formatDate(date),
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          InkWell(
+            onTap: () async {
+              final picked = await showDatePicker(
+                context: context,
+                initialDate: date,
+                firstDate: DateTime(2000),
+                lastDate: DateTime.now(),
+              );
+              if (picked != null) {
+                await onDateChanged(picked);
+              }
+            },
+            child: Icon(
+              Icons.edit_calendar,
+              size: 20,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHistorySection(
+    BuildContext context,
+    WidgetRef ref,
+    Book book,
+  ) {
+    final historiesAsync = ref.watch(readingHistoriesProvider(bookId));
+    final hasCurrentSession = book.startedAt != null;
+
+    return historiesAsync.when(
+      data: (histories) {
+        if (histories.isEmpty && !hasCurrentSession) {
+          return const SizedBox.shrink();
+        }
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '読書履歴',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const Divider(),
+                // 過去の履歴
+                ...histories.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final history = entry.value;
+                  return _buildHistoryRow(
+                    context,
+                    index + 1,
+                    startedAt: history.startedAt,
+                    completedAt: history.completedAt,
+                  );
+                }),
+                // 現在の読書セッション
+                if (hasCurrentSession)
+                  _buildHistoryRow(
+                    context,
+                    histories.length + 1,
+                    startedAt: book.startedAt,
+                    completedAt: book.completedAt,
+                    isCurrent: true,
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildHistoryRow(
+    BuildContext context,
+    int readCount, {
+    required DateTime? startedAt,
+    required DateTime? completedAt,
+    bool isCurrent = false,
+  }) {
+    final startStr =
+        startedAt != null ? _formatDate(startedAt) : '不明';
+    final endStr = completedAt != null
+        ? _formatDate(completedAt)
+        : '読書中';
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Text(
+        '$readCount回目: $startStr 〜 $endStr',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontWeight: isCurrent ? FontWeight.bold : null,
+            ),
       ),
     );
   }
@@ -286,6 +454,39 @@ class BookDetailScreen extends ConsumerWidget {
           const SnackBar(content: Text('本を削除しました')),
         );
       }
+    }
+  }
+
+  Future<void> _showReReadDialog(
+    BuildContext context,
+    WidgetRef ref,
+    Book book,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('もう一度読む'),
+        content: Text(
+          '「${book.title}」をもう一度読みますか？\n'
+          '現在の読書記録は履歴に保存されます。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('もう一度読む'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      await ref.read(booksProvider.notifier).reReadBook(book.id);
+      ref.invalidate(bookByIdProvider(bookId));
+      ref.invalidate(readingHistoriesProvider(bookId));
     }
   }
 }

--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -223,6 +223,7 @@ class BookDetailScreen extends ConsumerWidget {
                   await ref.read(booksProvider.notifier).updateBook(updatedBook);
                   ref.invalidate(bookByIdProvider(bookId));
                 },
+                allowFutureDate: true,
               ),
             if (book.status == ReadingStatus.completed)
               _buildEditableDateRow(
@@ -271,7 +272,9 @@ class BookDetailScreen extends ConsumerWidget {
     BuildContext context,
     String label,
     DateTime? date,
-    Future<void> Function(DateTime) onDateChanged,
+    Future<void> Function(DateTime) onDateChanged, {
+    bool allowFutureDate = false,
+  }
   ) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -296,11 +299,13 @@ class BookDetailScreen extends ConsumerWidget {
           ),
           IconButton(
             onPressed: () async {
+              final lastDate =
+                  allowFutureDate ? DateTime(2100) : DateTime.now();
               final picked = await showDatePicker(
                 context: context,
                 initialDate: date ?? DateTime.now(),
                 firstDate: DateTime(2000),
-                lastDate: DateTime.now(),
+                lastDate: lastDate,
               );
               if (picked != null) {
                 await onDateChanged(picked);

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -1,5 +1,6 @@
 import 'package:book_manager/models/book.dart';
 import 'package:book_manager/providers/books_provider.dart';
+import 'package:book_manager/utils/date_formatter.dart';
 import 'package:book_manager/widgets/book_search_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -301,9 +302,7 @@ class _DatePickerField extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final displayText = date != null
-        ? '${date!.year}/${date!.month.toString().padLeft(2, '0')}/${date!.day.toString().padLeft(2, '0')}'
-        : '未設定';
+    final displayText = date != null ? formatDate(date!) : '未設定';
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 16),

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -25,6 +25,8 @@ class BookFormScreen extends HookConsumerWidget {
 
     final selectedStatus = useState(book?.status ?? ReadingStatus.unread);
     final isLoading = useState(false);
+    final startedAt = useState<DateTime?>(book?.startedAt);
+    final completedAt = useState<DateTime?>(book?.completedAt);
 
     // coverUrlControllerの変更を監視してリビルドをトリガー
     useListenable(coverUrlController);
@@ -132,10 +134,47 @@ class BookFormScreen extends HookConsumerWidget {
                   .toList(),
               selected: {selectedStatus.value},
               onSelectionChanged: (Set<ReadingStatus> newSelection) {
-                selectedStatus.value = newSelection.first;
+                final newStatus = newSelection.first;
+                final oldStatus = selectedStatus.value;
+                selectedStatus.value = newStatus;
+
+                // ステータス変更時に日付をリセット
+                if (newStatus == ReadingStatus.unread) {
+                  startedAt.value = null;
+                  completedAt.value = null;
+                } else if (newStatus == ReadingStatus.reading) {
+                  completedAt.value = null;
+                  if (oldStatus == ReadingStatus.unread) {
+                    startedAt.value = DateTime.now();
+                  }
+                } else if (newStatus == ReadingStatus.completed) {
+                  if (startedAt.value == null) {
+                    startedAt.value = DateTime.now();
+                  }
+                  if (completedAt.value == null) {
+                    completedAt.value = DateTime.now();
+                  }
+                }
               },
             ),
-            const SizedBox(height: 32),
+            const SizedBox(height: 16),
+
+            // 日付ピッカーフィールド
+            if (selectedStatus.value == ReadingStatus.reading ||
+                selectedStatus.value == ReadingStatus.completed)
+              _DatePickerField(
+                label: '読書開始日',
+                date: startedAt.value,
+                onDateChanged: (date) => startedAt.value = date,
+              ),
+            if (selectedStatus.value == ReadingStatus.completed)
+              _DatePickerField(
+                label: '読了日',
+                date: completedAt.value,
+                onDateChanged: (date) => completedAt.value = date,
+              ),
+
+            const SizedBox(height: 16),
 
             // 表紙プレビュー
             if (coverUrlController.text.isNotEmpty) ...[
@@ -161,6 +200,8 @@ class BookFormScreen extends HookConsumerWidget {
                         isbnController.text,
                         coverUrlController.text,
                         selectedStatus.value,
+                        startedAt.value,
+                        completedAt.value,
                         isLoading,
                       ),
               icon: isLoading.value
@@ -187,6 +228,8 @@ class BookFormScreen extends HookConsumerWidget {
     String isbn,
     String coverUrl,
     ReadingStatus status,
+    DateTime? startedAt,
+    DateTime? completedAt,
     ValueNotifier<bool> isLoading,
   ) async {
     if (!formKey.currentState!.validate()) {
@@ -206,6 +249,8 @@ class BookFormScreen extends HookConsumerWidget {
             isbn: isbn.trim().isEmpty ? null : isbn.trim(),
             coverUrl: coverUrl.trim().isEmpty ? null : coverUrl.trim(),
             status: status,
+            startedAt: startedAt,
+            completedAt: completedAt,
           ),
         );
       } else {
@@ -215,6 +260,8 @@ class BookFormScreen extends HookConsumerWidget {
           isbn: isbn.trim().isEmpty ? null : isbn.trim(),
           coverUrl: coverUrl.trim().isEmpty ? null : coverUrl.trim(),
           status: status,
+          startedAt: startedAt,
+          completedAt: completedAt,
         );
       }
 
@@ -238,6 +285,50 @@ class BookFormScreen extends HookConsumerWidget {
     } finally {
       isLoading.value = false;
     }
+  }
+}
+
+class _DatePickerField extends HookWidget {
+
+  const _DatePickerField({
+    required this.label,
+    required this.date,
+    required this.onDateChanged,
+  });
+  final String label;
+  final DateTime? date;
+  final ValueChanged<DateTime?> onDateChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayText = date != null
+        ? '${date!.year}/${date!.month.toString().padLeft(2, '0')}/${date!.day.toString().padLeft(2, '0')}'
+        : '未設定';
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: InkWell(
+        onTap: () async {
+          final picked = await showDatePicker(
+            context: context,
+            initialDate: date ?? DateTime.now(),
+            firstDate: DateTime(2000),
+            lastDate: DateTime.now(),
+          );
+          if (picked != null) {
+            onDateChanged(picked);
+          }
+        },
+        child: InputDecorator(
+          decoration: InputDecoration(
+            labelText: label,
+            border: const OutlineInputBorder(),
+            suffixIcon: const Icon(Icons.calendar_today),
+          ),
+          child: Text(displayText),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -136,7 +136,6 @@ class BookFormScreen extends HookConsumerWidget {
               selected: {selectedStatus.value},
               onSelectionChanged: (Set<ReadingStatus> newSelection) {
                 final newStatus = newSelection.first;
-                final oldStatus = selectedStatus.value;
                 selectedStatus.value = newStatus;
 
                 // ステータス変更時に日付をリセット
@@ -145,7 +144,7 @@ class BookFormScreen extends HookConsumerWidget {
                   completedAt.value = null;
                 } else if (newStatus == ReadingStatus.reading) {
                   completedAt.value = null;
-                  if (oldStatus == ReadingStatus.unread) {
+                  if (startedAt.value == null) {
                     startedAt.value = DateTime.now();
                   }
                 } else if (newStatus == ReadingStatus.completed) {

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -167,7 +167,6 @@ class BookFormScreen extends HookConsumerWidget {
                 label: '読書開始日',
                 date: startedAt.value,
                 onDateChanged: (date) => startedAt.value = date,
-                allowFutureDate: true,
               ),
             if (selectedStatus.value == ReadingStatus.completed)
               _DatePickerField(
@@ -296,12 +295,10 @@ class _DatePickerField extends HookWidget {
     required this.label,
     required this.date,
     required this.onDateChanged,
-    this.allowFutureDate = false,
   });
   final String label;
   final DateTime? date;
   final ValueChanged<DateTime?> onDateChanged;
-  final bool allowFutureDate;
 
   @override
   Widget build(BuildContext context) {
@@ -311,13 +308,11 @@ class _DatePickerField extends HookWidget {
       padding: const EdgeInsets.only(bottom: 16),
       child: InkWell(
         onTap: () async {
-          final lastDate =
-              allowFutureDate ? DateTime(2100) : DateTime.now();
           final picked = await showDatePicker(
             context: context,
             initialDate: date ?? DateTime.now(),
             firstDate: DateTime(2000),
-            lastDate: lastDate,
+            lastDate: DateTime.now(),
           );
           if (picked != null) {
             onDateChanged(picked);

--- a/lib/screens/book_form_screen.dart
+++ b/lib/screens/book_form_screen.dart
@@ -167,6 +167,7 @@ class BookFormScreen extends HookConsumerWidget {
                 label: '読書開始日',
                 date: startedAt.value,
                 onDateChanged: (date) => startedAt.value = date,
+                allowFutureDate: true,
               ),
             if (selectedStatus.value == ReadingStatus.completed)
               _DatePickerField(
@@ -295,10 +296,12 @@ class _DatePickerField extends HookWidget {
     required this.label,
     required this.date,
     required this.onDateChanged,
+    this.allowFutureDate = false,
   });
   final String label;
   final DateTime? date;
   final ValueChanged<DateTime?> onDateChanged;
+  final bool allowFutureDate;
 
   @override
   Widget build(BuildContext context) {
@@ -308,11 +311,13 @@ class _DatePickerField extends HookWidget {
       padding: const EdgeInsets.only(bottom: 16),
       child: InkWell(
         onTap: () async {
+          final lastDate =
+              allowFutureDate ? DateTime(2100) : DateTime.now();
           final picked = await showDatePicker(
             context: context,
             initialDate: date ?? DateTime.now(),
             firstDate: DateTime(2000),
-            lastDate: DateTime.now(),
+            lastDate: lastDate,
           );
           if (picked != null) {
             onDateChanged(picked);

--- a/lib/utils/date_formatter.dart
+++ b/lib/utils/date_formatter.dart
@@ -1,0 +1,4 @@
+/// 日付を yyyy/MM/dd 形式にフォーマットする
+String formatDate(DateTime date) {
+  return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
+}

--- a/lib/widgets/book_card.dart
+++ b/lib/widgets/book_card.dart
@@ -55,8 +55,41 @@ class BookCard extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                     const Spacer(),
-                    // ステータスチップ
-                    _StatusChip(status: book.status),
+                    // ステータスチップ + 日付
+                    Row(
+                      children: [
+                        _StatusChip(status: book.status),
+                        if (book.status == ReadingStatus.completed &&
+                            book.completedAt != null) ...[
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Text(
+                              _formatDate(book.completedAt!),
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Colors.green[600],
+                                    fontSize: 10,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ] else if (book.status == ReadingStatus.reading &&
+                            book.startedAt != null) ...[
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Text(
+                              _formatDate(book.startedAt!),
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Colors.blue[600],
+                                    fontSize: 10,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
                   ],
                 ),
               ),
@@ -90,6 +123,10 @@ class BookCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
   }
 }
 

--- a/lib/widgets/book_card.dart
+++ b/lib/widgets/book_card.dart
@@ -62,7 +62,7 @@ class BookCard extends StatelessWidget {
                         if (book.status == ReadingStatus.completed &&
                             book.completedAt != null) ...[
                           const SizedBox(width: 4),
-                          Expanded(
+                          Flexible(
                             child: Text(
                               _formatDate(book.completedAt!),
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -76,7 +76,7 @@ class BookCard extends StatelessWidget {
                         ] else if (book.status == ReadingStatus.reading &&
                             book.startedAt != null) ...[
                           const SizedBox(width: 4),
-                          Expanded(
+                          Flexible(
                             child: Text(
                               _formatDate(book.startedAt!),
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(

--- a/lib/widgets/book_card.dart
+++ b/lib/widgets/book_card.dart
@@ -1,4 +1,5 @@
 import 'package:book_manager/models/book.dart';
+import 'package:book_manager/utils/date_formatter.dart';
 import 'package:flutter/material.dart';
 
 /// 本のカードウィジェット
@@ -64,7 +65,7 @@ class BookCard extends StatelessWidget {
                           const SizedBox(width: 4),
                           Flexible(
                             child: Text(
-                              _formatDate(book.completedAt!),
+                              formatDate(book.completedAt!),
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                                     color: Colors.green[600],
                                     fontSize: 10,
@@ -78,7 +79,7 @@ class BookCard extends StatelessWidget {
                           const SizedBox(width: 4),
                           Flexible(
                             child: Text(
-                              _formatDate(book.startedAt!),
+                              formatDate(book.startedAt!),
                               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                                     color: Colors.blue[600],
                                     fontSize: 10,
@@ -125,9 +126,6 @@ class BookCard extends StatelessWidget {
     );
   }
 
-  String _formatDate(DateTime date) {
-    return '${date.year}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')}';
-  }
 }
 
 class _StatusChip extends StatelessWidget {


### PR DESCRIPTION
## Summary
- Bookモデルに`startedAt`フィールドを追加し、読書開始日を記録可能に
- `ReadingHistory`モデル・リポジトリを新規作成し、再読（複数回読了）の履歴を管理
- DB v1→v2マイグレーション対応（`started_at`カラム・`reading_histories`テーブル追加）
- ステータス変更時の日付自動設定・クリアロジックを実装
- 詳細画面に日付編集（DatePicker）、「もう一度読む」ボタン、読書履歴セクションを追加
- フォーム画面にステータス連動の日付ピッカーを追加
- 一覧カードにステータスチップと日付を1行で統合表示

## 変更ファイル

| ファイル | 操作 | 概要 |
|---------|------|------|
| `lib/database/database_helper.dart` | 修正 | DB v1→v2マイグレーション、reading_historiesテーブル追加 |
| `lib/models/book.dart` | 修正 | `startedAt`フィールド追加（sentinelパターン） |
| `lib/models/reading_history.dart` | **新規** | 読書履歴モデル |
| `lib/repositories/book_repository.dart` | 修正 | startedAt自動設定/クリアロジック |
| `lib/repositories/reading_history_repository.dart` | **新規** | 履歴CRUD |
| `lib/providers/books_provider.dart` | 修正 | 履歴Provider追加、reReadBook、deleteBook更新 |
| `lib/screens/book_detail_screen.dart` | 修正 | 日付編集、再読ボタン、履歴表示 |
| `lib/screens/book_form_screen.dart` | 修正 | 日付ピッカー追加 |
| `lib/widgets/book_card.dart` | 修正 | カードに日付表示（チップ横に統合） |
| `lib/utils/date_formatter.dart` | **新規** | 日付フォーマット共通ユーティリティ |

## レビュー対応
### Round 1
- `book_card.dart`: `Expanded` → `Flexible`に変更し不要なスペース消費を解消
- `book_repository.dart`: `updateBook`でcompleted変更時に`startedAt`も自動設定
- `reading_history.dart`: 未使用の`toInsertMap`メソッドを削除
- `database_helper.dart`: FOREIGN KEYに`ON DELETE CASCADE`を追加

### Round 2
- 日付フォーマットを共通ユーティリティ（`utils/date_formatter.dart`）に集約
- `PRAGMA foreign_keys = ON`を追加し外部キー制約を有効化
- `startedAt`/`completedAt`がnullでもステータスに応じて「未設定」表示+DatePickerで設定可能に
- 編集アイコンを`InkWell`から`IconButton`（tooltip付き）に変更しアクセシビリティ向上

### Round 3
- `updateBook`で`DateTime.now()`を1回だけ取得して使い回し一貫性を確保
- `_buildEditableDateRow`から未使用引数を削除
- `hasCurrentSession`の判定に`completedAt`も加味（v1→v2移行データ対応）
- 読書履歴のエラー時にエラーメッセージ+再試行ボタンを表示

### Round 4・5
- `allowFutureDate`パラメータを完全に削除し、日付選択を今日以前に制限
- reading切り替え時の`startedAt`自動設定条件を`oldStatus == unread`から`startedAt == null`に変更し、Repository側のロジックとUI表示を一致させた

## Test plan
- [ ] `flutter analyze`でエラーなし
- [ ] 新規に本を登録 →「読書中」にする → startedAtが自動設定される
- [ ] 「読了」にする → completedAtが自動設定される
- [ ] 詳細画面で日付を手動編集できる
- [ ] 「もう一度読む」→ 履歴に保存され、ステータスが「読書中」に戻る
- [ ] 読書履歴セクションに「○回目: 開始日 〜 読了日」が表示される（現在の読書も含む）
- [ ] 本を削除 → 関連履歴も削除される
- [ ] 既存データ（DB v1）からのマイグレーションが正常に動作する

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)