### PR TITLE
登録済み書籍のテキスト検索機能を追加

### DIFF
--- a/lib/providers/books_provider.dart
+++ b/lib/providers/books_provider.dart
@@ -117,7 +117,7 @@ final booksProvider = AsyncNotifierProvider<BooksNotifier, List<Book>>(() {
 final filteredBooksProvider = Provider<AsyncValue<List<Book>>>((ref) {
   final booksAsync = ref.watch(booksProvider);
   final selectedStatus = ref.watch(selectedStatusFilterProvider);
-  final query = ref.watch(searchQueryProvider).toLowerCase();
+  final query = ref.watch(searchQueryProvider).trim().toLowerCase();
 
   return booksAsync.whenData((books) {
     var filtered = books;

--- a/lib/providers/books_provider.dart
+++ b/lib/providers/books_provider.dart
@@ -20,6 +20,9 @@ final selectedStatusFilterProvider = StateProvider<ReadingStatus?>((ref) {
   return null;
 });
 
+/// テキスト検索クエリ
+final searchQueryProvider = StateProvider<String>((ref) => '');
+
 /// 本のリストを管理するNotifier
 class BooksNotifier extends AsyncNotifier<List<Book>> {
   @override
@@ -114,12 +117,23 @@ final booksProvider = AsyncNotifierProvider<BooksNotifier, List<Book>>(() {
 final filteredBooksProvider = Provider<AsyncValue<List<Book>>>((ref) {
   final booksAsync = ref.watch(booksProvider);
   final selectedStatus = ref.watch(selectedStatusFilterProvider);
+  final query = ref.watch(searchQueryProvider).toLowerCase();
 
   return booksAsync.whenData((books) {
-    if (selectedStatus == null) {
-      return books;
+    var filtered = books;
+    if (selectedStatus != null) {
+      filtered = filtered.where((b) => b.status == selectedStatus).toList();
     }
-    return books.where((book) => book.status == selectedStatus).toList();
+    if (query.isNotEmpty) {
+      filtered = filtered
+          .where(
+            (b) =>
+                b.title.toLowerCase().contains(query) ||
+                b.author.toLowerCase().contains(query),
+          )
+          .toList();
+    }
+    return filtered;
   });
 });
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,14 +5,16 @@ import 'package:book_manager/screens/book_form_screen.dart';
 import 'package:book_manager/widgets/book_card.dart';
 import 'package:book_manager/widgets/status_filter.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// ホーム画面（本一覧）
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends HookConsumerWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final searchController = useTextEditingController();
     final filteredBooks = ref.watch(filteredBooksProvider);
 
     return Scaffold(
@@ -22,6 +24,37 @@ class HomeScreen extends ConsumerWidget {
       ),
       body: Column(
         children: [
+          // 検索バー
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: TextField(
+              controller: searchController,
+              decoration: InputDecoration(
+                hintText: 'タイトル・著者名で検索',
+                prefixIcon: const Icon(Icons.search),
+                suffixIcon: ValueListenableBuilder<TextEditingValue>(
+                  valueListenable: searchController,
+                  builder: (context, value, child) {
+                    if (value.text.isEmpty) return const SizedBox.shrink();
+                    return IconButton(
+                      icon: const Icon(Icons.clear),
+                      onPressed: () {
+                        searchController.clear();
+                        ref.read(searchQueryProvider.notifier).state = '';
+                      },
+                    );
+                  },
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                contentPadding: EdgeInsets.zero,
+              ),
+              onChanged: (value) {
+                ref.read(searchQueryProvider.notifier).state = value;
+              },
+            ),
+          ),
           // ステータスフィルター
           const StatusFilter(),
           // 本の一覧
@@ -29,6 +62,13 @@ class HomeScreen extends ConsumerWidget {
             child: filteredBooks.when(
               data: (books) {
                 if (books.isEmpty) {
+                  final hasQuery =
+                      ref.read(searchQueryProvider).isNotEmpty;
+                  final hasStatusFilter =
+                      ref.read(selectedStatusFilterProvider) != null;
+                  if (hasQuery || hasStatusFilter) {
+                    return _buildNoResultsState(context);
+                  }
                   return _buildEmptyState(context);
                 }
                 return _buildBookGrid(context, books);
@@ -93,6 +133,28 @@ class HomeScreen extends ConsumerWidget {
             '右下のボタンから本を追加してください',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: Colors.grey[500],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoResultsState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.search_off,
+            size: 80,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '該当する本が見つかりません',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: Colors.grey[600],
                 ),
           ),
         ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -34,7 +34,7 @@ class HomeScreen extends HookConsumerWidget {
                 prefixIcon: const Icon(Icons.search),
                 suffixIcon: ValueListenableBuilder<TextEditingValue>(
                   valueListenable: searchController,
-                  builder: (context, value, child) {
+                  builder: (context, value, _) {
                     if (value.text.isEmpty) return const SizedBox.shrink();
                     return IconButton(
                       icon: const Icon(Icons.clear),
@@ -63,7 +63,7 @@ class HomeScreen extends HookConsumerWidget {
               data: (books) {
                 if (books.isEmpty) {
                   final hasQuery =
-                      ref.read(searchQueryProvider).isNotEmpty;
+                      ref.read(searchQueryProvider).trim().isNotEmpty;
                   final hasStatusFilter =
                       ref.read(selectedStatusFilterProvider) != null;
                   if (hasQuery || hasStatusFilter) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,7 +14,8 @@ class HomeScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final searchController = useTextEditingController();
+    final searchController =
+        useTextEditingController(text: ref.read(searchQueryProvider));
     final filteredBooks = ref.watch(filteredBooksProvider);
 
     return Scaffold(


### PR DESCRIPTION
## Summary
- ホーム画面にタイトル・著者名でリアルタイムにフィルタリングできる検索バーを追加
- 既存のステータスフィルターと組み合わせて動作
- 検索結果が0件の場合は「該当する本が見つかりません」を表示

## 変更内容
- `searchQueryProvider`を追加し、`filteredBooksProvider`にテキスト検索フィルターを統合
- `HomeScreen`を`HookConsumerWidget`化し、検索バーUI（クリアボタン付き）を追加
- 大文字小文字を区別しない部分一致検索（`toLowerCase()`）

## Test plan
- [ ] 検索バーにテキスト入力 → タイトル・著者名でリアルタイムに絞り込まれる
- [ ] ステータスフィルターと検索を組み合わせて動作する
- [ ] クリアボタン（×）で検索をリセットし全件表示に戻る
- [ ] 検索結果が0件の場合、「該当する本が見つかりません」が表示される
- [ ] 大文字小文字を区別しない検索が動作する
- [ ] `flutter analyze` でエラーなし

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)