### PR TITLE
ボトムナビゲーションバーを追加し画面切り替えを導入 (#36)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,21 +1,27 @@
 PODS:
   - Flutter (1.0.0)
+  - package_info_plus (0.4.5):
+    - Flutter
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e

--- a/lib/providers/package_info_provider.dart
+++ b/lib/providers/package_info_provider.dart
@@ -1,0 +1,7 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// アプリバージョン情報のプロバイダー
+final packageInfoProvider = FutureProvider<PackageInfo>((ref) {
+  return PackageInfo.fromPlatform();
+});

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -12,9 +12,14 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class MainScreen extends HookConsumerWidget {
   const MainScreen({super.key});
 
-  // 追加ボタン（index 2）を除いたタブインデックスのマッピング
+  // 追加ボタン（index 2）は画面遷移専用でIndexedStackに含まない
   static const _addIndex = 2;
-  static const _navToStack = {0: 0, 1: 1, 3: 2};
+
+  /// ナビゲーションバーのインデックスをIndexedStackのインデックスに変換
+  static int _toStackIndex(int navIndex) {
+    assert(navIndex != _addIndex, '追加ボタンはIndexedStackに対応しません');
+    return navIndex > _addIndex ? navIndex - 1 : navIndex;
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -22,7 +27,7 @@ class MainScreen extends HookConsumerWidget {
 
     return Scaffold(
       body: IndexedStack(
-        index: _navToStack[selectedIndex.value] ?? 0,
+        index: _toStackIndex(selectedIndex.value),
         children: const [
           HomeScreen(),
           StatisticsScreen(),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 /// 設定画面
 class SettingsScreen extends ConsumerWidget {
@@ -29,10 +30,16 @@ class SettingsScreen extends ConsumerWidget {
             title: Text('アプリ名'),
             subtitle: Text('読書管理'),
           ),
-          const ListTile(
-            leading: Icon(Icons.new_releases_outlined),
-            title: Text('バージョン'),
-            subtitle: Text('1.0.0'),
+          FutureBuilder<PackageInfo>(
+            future: PackageInfo.fromPlatform(),
+            builder: (context, snapshot) {
+              final version = snapshot.data?.version ?? '';
+              return ListTile(
+                leading: const Icon(Icons.new_releases_outlined),
+                title: const Text('バージョン'),
+                subtitle: Text(version),
+              );
+            },
           ),
         ],
       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,11 +1,6 @@
+import 'package:book_manager/providers/package_info_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-
-/// アプリバージョン情報のプロバイダー
-final packageInfoProvider = FutureProvider<PackageInfo>((ref) {
-  return PackageInfo.fromPlatform();
-});
 
 /// 設定画面
 class SettingsScreen extends ConsumerWidget {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,12 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+/// アプリバージョン情報のプロバイダー
+final packageInfoProvider = FutureProvider<PackageInfo>((ref) {
+  return PackageInfo.fromPlatform();
+});
+
 /// 設定画面
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final packageInfoAsync = ref.watch(packageInfoProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('設定'),
@@ -30,16 +37,16 @@ class SettingsScreen extends ConsumerWidget {
             title: Text('アプリ名'),
             subtitle: Text('読書管理'),
           ),
-          FutureBuilder<PackageInfo>(
-            future: PackageInfo.fromPlatform(),
-            builder: (context, snapshot) {
-              final version = snapshot.data?.version ?? '';
-              return ListTile(
-                leading: const Icon(Icons.new_releases_outlined),
-                title: const Text('バージョン'),
-                subtitle: Text(version),
-              );
-            },
+          ListTile(
+            leading: const Icon(Icons.new_releases_outlined),
+            title: const Text('バージョン'),
+            subtitle: Text(
+              packageInfoAsync.when(
+                data: (info) => info.version,
+                loading: () => '',
+                error: (_, _) => '取得失敗',
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/widgets/book_search_dialog.dart
+++ b/lib/widgets/book_search_dialog.dart
@@ -104,7 +104,7 @@ class _BookSearchSheet extends HookConsumerWidget {
                 controller: scrollController,
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 itemCount: results.length,
-                separatorBuilder: (_, __) => const Divider(height: 1),
+                separatorBuilder: (_, _) => const Divider(height: 1),
                 itemBuilder: (context, index) {
                   final result = results[index];
                   return _SearchResultTile(
@@ -154,7 +154,7 @@ class _SearchResultTile extends StatelessWidget {
             ? Image.network(
                 result.coverUrl!,
                 fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => const Icon(
+                errorBuilder: (_, _, _) => const Icon(
                   Icons.book,
                   size: 32,
                   color: Colors.grey,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import package_info_plus
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -256,6 +264,11 @@ packages:
     version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -391,18 +404,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -427,6 +440,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:
@@ -644,10 +673,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:
@@ -720,6 +749,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.6.2
+  sdk: ^3.9.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.9.0
+  flutter: ">=3.32.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   sqflite: ^2.4.2
   path: ^1.9.0
   uuid: ^4.5.3
+  package_info_plus: ^9.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -44,7 +44,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // 統計画面のAppBarタイトルが表示されることを確認
-    expect(find.text('統計'), findsNWidgets(2)); // ナビラベル + AppBarタイトル
+    expect(find.widgetWithText(AppBar, '統計'), findsOneWidget);
   });
 
   testWidgets('Tapping settings tab shows settings screen',
@@ -60,9 +60,13 @@ void main() {
     await tester.pumpAndSettle();
 
     // 設定画面の内容が表示されることを確認
-    expect(find.text('設定'), findsNWidgets(2)); // ナビラベル + AppBarタイトル
-    expect(find.text('バージョン'), findsOneWidget);
-    expect(find.text('1.0.0'), findsOneWidget);
+    expect(find.widgetWithText(AppBar, '設定'), findsOneWidget);
+    // バージョン行が表示されていることを確認（動的取得のため特定の値に依存しない）
+    final versionTileFinder = find.ancestor(
+      of: find.text('バージョン'),
+      matching: find.byType(ListTile),
+    );
+    expect(versionTileFinder, findsOneWidget);
   });
 
   testWidgets('Tapping add button navigates to BookFormScreen',

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,16 +1,26 @@
 import 'package:book_manager/main.dart';
 import 'package:book_manager/models/book.dart';
 import 'package:book_manager/providers/books_provider.dart';
+import 'package:book_manager/providers/package_info_provider.dart';
 import 'package:book_manager/screens/book_form_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
-/// テスト用のProviderScope（実DBに依存しない）
+/// テスト用のProviderScope（実DBやプラットフォームAPIに依存しない）
 ProviderScope createTestApp() {
   return ProviderScope(
     overrides: [
       booksProvider.overrideWith(() => _FakeBooksNotifier()),
+      packageInfoProvider.overrideWith((ref) async {
+        return PackageInfo(
+          appName: '読書管理',
+          packageName: 'com.example.book_manager',
+          version: '1.0.0',
+          buildNumber: '1',
+        );
+      }),
     ],
     child: const BookManagerApp(),
   );
@@ -69,12 +79,9 @@ void main() {
 
     // 設定画面の内容が表示されることを確認
     expect(find.widgetWithText(AppBar, '設定'), findsOneWidget);
-    // バージョン行が表示されていることを確認（動的取得のため特定の値に依存しない）
-    final versionTileFinder = find.ancestor(
-      of: find.text('バージョン'),
-      matching: find.byType(ListTile),
-    );
-    expect(versionTileFinder, findsOneWidget);
+    // バージョンが表示されていることを確認
+    expect(find.text('バージョン'), findsOneWidget);
+    expect(find.text('1.0.0'), findsOneWidget);
   });
 
   testWidgets('Tapping add button navigates to BookFormScreen',


### PR DESCRIPTION
## 概要

現在はホーム画面（本一覧）のみの単一画面構成だったため、ボトムナビゲーションバーを導入し画面切り替えを可能にした。今後の機能拡張の土台となる画面構成を整備。

## 変更内容

- `MainScreen`を新設し`NavigationBar`+`IndexedStack`でタブ管理（本棚/統計/追加/設定）
- 追加ボタンをナビゲーションバー中央に配置し`BookFormScreen`へ遷移（タブ切り替えではなく画面遷移）
- `StatisticsScreen`を追加（登録冊数サマリー・ステータス別内訳を`LinearProgressIndicator`で表示）
- `SettingsScreen`を追加（アプリ名・バージョン情報のプレースホルダー）
- `HomeScreen`からFABを削除し`main.dart`のエントリポイントを`MainScreen`に変更

### 変更対象ファイル

| ファイル | 操作 | 概要 |
|---------|------|------|
| `lib/screens/main_screen.dart` | 新規 | `NavigationBar` + `IndexedStack` のシェル画面 |
| `lib/screens/statistics_screen.dart` | 新規 | 読書統計画面（登録冊数、ステータス別内訳） |
| `lib/screens/settings_screen.dart` | 新規 | 設定画面プレースホルダー（アプリ情報・バージョン） |
| `lib/main.dart` | 修正 | `home: HomeScreen()` → `home: MainScreen()` に変更 |
| `lib/screens/home_screen.dart` | 修正 | FAB削除、空状態メッセージ更新、不要import削除 |
| `test/widget_test.dart` | 修正 | ナビゲーションバーの表示テスト追加 |

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [x] テスト
- [ ] その他

## テスト

- [x] `flutter analyze` エラーなし
- [x] テストコード追加/更新済み（ナビゲーションバーラベルの表示確認）
- [ ] 動作確認済み

### 動作確認項目
- [ ] アプリ起動 → 本棚タブがデフォルト表示、既存機能（検索・フィルター）が正常動作
- [ ] 追加ボタンタップ → BookFormScreenへ遷移し本を登録できる
- [ ] 統計タブ → ステータス別冊数が正しく表示（0冊時は空状態メッセージ）
- [ ] 設定タブ → バージョン情報が表示
- [ ] タブ切り替え → 各タブの状態が保持される（検索文字列が消えない等）
- [ ] 本棚から詳細画面へ遷移 → ナビゲーションバーが隠れてフルスクリーン表示

## 関連Issue

Closes #36

## レビュー時の注意点

- `NavigationBar`の「追加」タブはタブ切り替えではなく`BookFormScreen`への画面遷移として実装（`selectedIndex`を変更せずreturn）
- `IndexedStack`でタブ切り替え時の状態保持を実現
- 統計画面のカラー（未読=grey, 読書中=blue, 読了=green）は既存`book_card.dart`の`_StatusChip`に準拠