### PR TITLE
docs: AIコーディングアシスタント向けガイドラインを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,220 @@
+# Copilot Instructions
+
+このプロジェクトはFlutter製の書籍管理アプリ（book_manager）です。
+AIアシスタントがコード生成・補完を行う際は、以下の規約に従ってください。
+
+## 開発環境
+
+- Flutter 3.38.7 (stable) / Dart 3.6.2+（FVMで管理）
+- コマンドは `fvm flutter ...` / `fvm dart ...` で実行
+- 対応OS: Android 7.0+ (API 24) / iOS 15.0+
+
+## アーキテクチャ
+
+Riverpod + Flutter Hooks を採用した4層アーキテクチャ。
+
+```
+lib/
+├── screens/       # 画面（HookConsumerWidget）
+├── widgets/       # 再利用可能なウィジェット
+├── providers/     # 状態管理（AsyncNotifier / StateProvider）
+├── repositories/  # データアクセス層
+├── models/        # データモデル（不変オブジェクト）
+├── services/      # 外部API連携
+├── database/      # SQLite（DatabaseHelper）
+└── utils/         # ユーティリティ
+```
+
+### データフロー
+
+```
+Screen (HookConsumerWidget)
+  → ref.watch(provider) で状態を監視
+Provider (AsyncNotifier)
+  → ref.read(repositoryProvider) でリポジトリ呼び出し
+Repository
+  → DatabaseHelper でSQLite操作
+```
+
+## コーディング規約
+
+### 必須ルール
+
+- **シングルクォート** を使用（`'text'`）
+- **package import** のみ使用（`import 'package:book_manager/...'`、相対importは禁止）
+- **変数は `final` を優先**（`final locals`, `final fields`, `final in for-each`）
+- **`const` コンストラクタを優先**（Widget生成時は常に `const` を検討）
+- **戻り値型を常に宣言**（`void`, `Future<void>` 等を省略しない）
+- **`@override` アノテーション** を必ず付与
+- **`super` パラメータ** を使用（`super.key` 等）
+- **`print()` 禁止** — デバッグ出力は `debugPrint()` を使用
+- **strict-casts / strict-raw-types 有効** — 暗黙の型変換・raw型は禁止
+
+### 非同期処理
+
+- **`avoid_void_async`**: コールバック等で `async void` を書かない。戻り値が不要でも `Future<void>` を返す
+- **`unawaited_futures`**: await不要なFutureは `unawaited()` で明示的にラップ
+- **`discarded_futures`**: Futureを無視しない
+- **`cancel_subscriptions` / `close_sinks`**: StreamSubscription/Sinkは必ず解放
+
+### スタイル
+
+- `curly_braces_in_flow_control_structures: true` — if/for/while に常に `{}`
+- `sort_constructors_first: true` — クラス内でコンストラクタを最初に配置
+- `sized_box_for_whitespace` / `use_colored_box` / `use_decorated_box` — 適切なウィジェットを使い分け
+- importは `directives_ordering` に従い整列
+
+## 状態管理パターン
+
+### Widgetの基底クラス
+
+```dart
+// Hooks + Riverpod を組み合わせる場合
+class MyScreen extends HookConsumerWidget {
+  const MyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Hooks で局所状態
+    final controller = useTextEditingController();
+    final isLoading = useState(false);
+
+    // Riverpod でグローバル状態を監視
+    final booksAsync = ref.watch(booksProvider);
+
+    return booksAsync.when(
+      data: (books) => ...,
+      loading: () => const CircularProgressIndicator(),
+      error: (error, stack) => ...,
+    );
+  }
+}
+```
+
+### Provider定義
+
+```dart
+// リポジトリ
+final bookRepositoryProvider = Provider<BookRepository>((ref) {
+  return BookRepository();
+});
+
+// 非同期状態（CRUD操作あり）
+class BooksNotifier extends AsyncNotifier<List<Book>> {
+  @override
+  Future<List<Book>> build() async { ... }
+
+  Future<void> addBook(...) async {
+    // 処理後にデータを再取得
+    ref.invalidateSelf();
+  }
+}
+final booksProvider = AsyncNotifierProvider<BooksNotifier, List<Book>>(...);
+
+// 派生プロバイダ（フィルタリング等）
+final filteredBooksProvider = Provider<AsyncValue<List<Book>>>((ref) {
+  final books = ref.watch(booksProvider);
+  final query = ref.watch(searchQueryProvider);
+  // フィルタロジック
+});
+
+// 単純なUI状態
+final searchQueryProvider = StateProvider<String>((ref) => '');
+
+// IDで個別データ取得
+final bookByIdProvider = FutureProvider.family<Book?, String>((ref, id) async { ... });
+```
+
+## モデル定義パターン
+
+```dart
+class Book {
+  const Book({
+    required this.id,
+    required this.title,
+    this.author,
+  });
+
+  // コンストラクタを先頭に配置
+  factory Book.fromMap(Map<String, dynamic> map) { ... }
+
+  final String id;
+  final String title;
+  final String? author;
+
+  Map<String, dynamic> toMap() { ... }
+
+  // nullable フィールドの copyWith にはセンチネルパターンを使用
+  static const _sentinel = Object();
+
+  Book copyWith({
+    String? title,
+    Object? author = _sentinel,
+  }) {
+    return Book(
+      id: id,
+      title: title ?? this.title,
+      author: author == _sentinel ? this.author : author as String?,
+    );
+  }
+}
+```
+
+### Enumパターン
+
+```dart
+enum ReadingStatus {
+  unread,
+  reading,
+  completed;
+
+  // 拡張メソッドではなくenum内にメソッドを定義
+  String get displayName => switch (this) {
+    ReadingStatus.unread => '未読',
+    ReadingStatus.reading => '読書中',
+    ReadingStatus.completed => '読了',
+  };
+
+  int get value => index;
+
+  static ReadingStatus fromValue(int value) {
+    return ReadingStatus.values[value];
+  }
+}
+```
+
+## データベース
+
+- **SQLite**（sqfliteパッケージ）を使用
+- `DatabaseHelper` はシングルトンパターン
+- スキーマバージョン管理: `_onUpgrade()` でマイグレーション実施
+- IDは **UUID**（uuidパッケージ）で生成
+
+## テスト
+
+```dart
+testWidgets('説明', (WidgetTester tester) async {
+  await tester.pumpWidget(
+    const ProviderScope(child: BookManagerApp()),
+  );
+  await tester.pumpAndSettle();
+
+  // 検証
+  expect(find.text('本棚'), findsOneWidget);
+});
+```
+
+- ProviderScope でラップしてテスト
+- `pumpAndSettle()` でアニメーション完了を待つ
+
+## Git規約
+
+- ベースブランチ: `develop`
+- ブランチ命名: `feature/機能名`, `fix/バグ内容`, `refactor/対象`, `docs/内容`
+- コミットメッセージ: `種別: 変更内容の要約`（種別: feat / fix / docs / refactor / test / chore）
+
+## 言語
+
+- コード中の変数名・関数名・クラス名: **英語**
+- UIテキスト・コメント・ドキュメント: **日本語**
+- **PRレビューコメント: 日本語** で記述すること

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -182,10 +182,28 @@ extension ReadingStatusExtension on ReadingStatus {
     }
   }
 
-  int get value => index;
+  int get value {
+    switch (this) {
+      case ReadingStatus.unread:
+        return 0;
+      case ReadingStatus.reading:
+        return 1;
+      case ReadingStatus.completed:
+        return 2;
+    }
+  }
 
   static ReadingStatus fromValue(int value) {
-    return ReadingStatus.values[value];
+    switch (value) {
+      case 0:
+        return ReadingStatus.unread;
+      case 1:
+        return ReadingStatus.reading;
+      case 2:
+        return ReadingStatus.completed;
+      default:
+        return ReadingStatus.unread;
+    }
   }
 }
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@ Riverpod + Flutter Hooks を採用。主要4層 + 補助ディレクトリで構
 
 ```
 lib/
-├── screens/       # 画面（HookConsumerWidget）        ┐
+├── screens/       # 画面（ConsumerWidget / HookConsumerWidget） ┐
 ├── providers/     # 状態管理（AsyncNotifier等）         │ 主要4層
 ├── repositories/  # データアクセス層                     │
 ├── models/        # データモデル（不変オブジェクト）       ┘
@@ -28,7 +28,7 @@ lib/
 ### データフロー
 
 ```
-Screen (HookConsumerWidget)
+Screen (ConsumerWidget / HookConsumerWidget)
   → ref.watch(provider) で状態を監視
 Provider (AsyncNotifier)
   → ref.read(bookRepositoryProvider) でリポジトリ呼び出し
@@ -69,7 +69,8 @@ Repository
 ### Widgetの基底クラス
 
 ```dart
-// Hooks + Riverpod を組み合わせる場合
+// Hooksが不要な場合は ConsumerWidget を使用
+// Hooks + Riverpod を組み合わせる場合は HookConsumerWidget を使用
 class MyScreen extends HookConsumerWidget {
   const MyScreen({super.key});
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -133,7 +133,7 @@ class Book {
   const Book({
     required this.id,
     required this.title,
-    this.author,
+    required this.author,
   });
 
   // コンストラクタを先頭に配置
@@ -141,7 +141,7 @@ class Book {
 
   final String id;
   final String title;
-  final String? author;
+  final String author;
 
   Map<String, dynamic> toMap() { ... }
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ lib/
 Screen (HookConsumerWidget)
   → ref.watch(provider) で状態を監視
 Provider (AsyncNotifier)
-  → ref.read(repositoryProvider) でリポジトリ呼び出し
+  → ref.read(bookRepositoryProvider) でリポジトリ呼び出し
 Repository
   → DatabaseHelper でSQLite操作
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,24 +5,24 @@ AIアシスタントがコード生成・補完を行う際は、以下の規約
 
 ## 開発環境
 
-- Flutter 3.38.7 (stable) / Dart 3.6.2+（FVMで管理）
+- Flutter stable（FVMで管理、バージョンは `.fvmrc` に従う）
 - コマンドは `fvm flutter ...` / `fvm dart ...` で実行
-- 対応OS: Android 7.0+ (API 24) / iOS 15.0+
+- 対応OS: Android（`flutter.minSdkVersion` に従う） / iOS 17.6+
 
 ## アーキテクチャ
 
-Riverpod + Flutter Hooks を採用した4層アーキテクチャ。
+Riverpod + Flutter Hooks を採用。主要4層 + 補助ディレクトリで構成。
 
 ```
 lib/
-├── screens/       # 画面（HookConsumerWidget）
-├── widgets/       # 再利用可能なウィジェット
-├── providers/     # 状態管理（AsyncNotifier / StateProvider）
-├── repositories/  # データアクセス層
-├── models/        # データモデル（不変オブジェクト）
-├── services/      # 外部API連携
-├── database/      # SQLite（DatabaseHelper）
-└── utils/         # ユーティリティ
+├── screens/       # 画面（HookConsumerWidget）        ┐
+├── providers/     # 状態管理（AsyncNotifier等）         │ 主要4層
+├── repositories/  # データアクセス層                     │
+├── models/        # データモデル（不変オブジェクト）       ┘
+├── widgets/       # 再利用可能なウィジェット              ┐
+├── services/      # 外部API連携                         │ 補助
+├── database/      # SQLite（DatabaseHelper）            │
+└── utils/         # ユーティリティ                       ┘
 ```
 
 ### データフロー
@@ -116,6 +116,7 @@ final filteredBooksProvider = Provider<AsyncValue<List<Book>>>((ref) {
   final books = ref.watch(booksProvider);
   final query = ref.watch(searchQueryProvider);
   // フィルタロジック
+  return ...;
 });
 
 // 単純なUI状態
@@ -145,8 +146,7 @@ class Book {
   Map<String, dynamic> toMap() { ... }
 
   // nullable フィールドの copyWith にはセンチネルパターンを使用
-  static const _sentinel = Object();
-
+  // _sentinel はファイル先頭にトップレベルで定義: const _sentinel = Object();
   Book copyWith({
     String? title,
     Object? author = _sentinel,
@@ -166,14 +166,21 @@ class Book {
 enum ReadingStatus {
   unread,
   reading,
-  completed;
+  completed,
+}
 
-  // 拡張メソッドではなくenum内にメソッドを定義
-  String get displayName => switch (this) {
-    ReadingStatus.unread => '未読',
-    ReadingStatus.reading => '読書中',
-    ReadingStatus.completed => '読了',
-  };
+// extension で displayName / value / fromValue を提供
+extension ReadingStatusExtension on ReadingStatus {
+  String get displayName {
+    switch (this) {
+      case ReadingStatus.unread:
+        return '未読';
+      case ReadingStatus.reading:
+        return '読書中';
+      case ReadingStatus.completed:
+        return '読了';
+    }
+  }
 
   int get value => index;
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Flutter製の書籍管理アプリ。本の登録・ステータス管理・メ�
 
 ## 開発環境
 
-- Flutter 3.38.7 (stable) / Dart 3.6.2+
+- Flutter stable（FVMで管理、バージョンは `.fvmrc` に従う）
 - バージョン管理: FVM
 - コマンドは必ず `fvm flutter ...` / `fvm dart ...` で実行すること
 
@@ -25,17 +25,18 @@ fvm flutter run               # アプリ実行
 
 ## アーキテクチャ
 
-Riverpod + Flutter Hooks の4層構成:
+Riverpod + Flutter Hooks を採用。主要4層 + 補助ディレクトリで構成:
 
 ```
-screens/      → HookConsumerWidget（画面）
-providers/    → AsyncNotifier / StateProvider（状態管理）
-repositories/ → データアクセス層
-models/       → 不変データモデル（fromMap/toMap/copyWith）
-services/     → 外部API連携
-database/     → SQLite（DatabaseHelper、シングルトン）
-widgets/      → 再利用可能なウィジェット
-utils/        → ユーティリティ
+lib/
+├── screens/       → 画面（HookConsumerWidget）        ┐
+├── providers/     → 状態管理（AsyncNotifier等）         │ 主要4層
+├── repositories/  → データアクセス層                     │
+├── models/        → 不変データモデル（fromMap/toMap等）  ┘
+├── widgets/       → 再利用可能なウィジェット              ┐
+├── services/      → 外部API連携                         │ 補助
+├── database/      → SQLite（DatabaseHelper）            │
+└── utils/         → ユーティリティ                       ┘
 ```
 
 ### データフロー
@@ -97,7 +98,10 @@ class MyScreen extends HookConsumerWidget {
 ### Model（nullableフィールドのcopyWithにはセンチネルパターン）
 
 ```dart
-static const _sentinel = Object();
+// ファイル先頭にトップレベルで定義
+const _sentinel = Object();
+
+// クラス内の copyWith メソッド
 Book copyWith({Object? memo = _sentinel}) {
   return Book(memo: memo == _sentinel ? this.memo : memo as String?);
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ lib/
 
 ### データフロー
 
-Screen → `ref.watch(provider)` → Provider → `ref.read(repository)` → Repository → DatabaseHelper
+Screen → `ref.watch(provider)` → Provider → `ref.read(xxxRepositoryProvider)` → Repository → DatabaseHelper
 
 ### 状態更新
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Riverpod + Flutter Hooks を採用。主要4層 + 補助ディレクトリで構
 
 ```
 lib/
-├── screens/       → 画面（HookConsumerWidget）        ┐
+├── screens/       → 画面（ConsumerWidget / HookConsumerWidget） ┐
 ├── providers/     → 状態管理（AsyncNotifier等）         │ 主要4層
 ├── repositories/  → データアクセス層                     │
 ├── models/        → 不変データモデル（fromMap/toMap等）  ┘
@@ -79,6 +79,7 @@ Screen → `ref.watch(provider)` → Provider → `ref.read(xxxRepositoryProvide
 ### Widget
 
 ```dart
+// Hooksが不要な場合は ConsumerWidget を使用
 class MyScreen extends HookConsumerWidget {
   const MyScreen({super.key});
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+このファイルはClaude Codeがプロジェクトを理解するためのガイドです。
+
+## プロジェクト概要
+
+Flutter製の書籍管理アプリ。本の登録・ステータス管理・メモ・統計機能を提供する。
+
+## 開発環境
+
+- Flutter 3.38.7 (stable) / Dart 3.6.2+
+- バージョン管理: FVM
+- コマンドは必ず `fvm flutter ...` / `fvm dart ...` で実行すること
+
+## よく使うコマンド
+
+```bash
+fvm flutter pub get           # 依存パッケージ取得
+fvm flutter analyze           # 静的解析
+fvm flutter test              # 全テスト実行
+fvm flutter test test/widget_test.dart  # 個別テスト実行
+fvm dart run build_runner build --delete-conflicting-outputs  # コード生成
+fvm flutter run               # アプリ実行
+```
+
+## アーキテクチャ
+
+Riverpod + Flutter Hooks の4層構成:
+
+```
+screens/      → HookConsumerWidget（画面）
+providers/    → AsyncNotifier / StateProvider（状態管理）
+repositories/ → データアクセス層
+models/       → 不変データモデル（fromMap/toMap/copyWith）
+services/     → 外部API連携
+database/     → SQLite（DatabaseHelper、シングルトン）
+widgets/      → 再利用可能なウィジェット
+utils/        → ユーティリティ
+```
+
+### データフロー
+
+Screen → `ref.watch(provider)` → Provider → `ref.read(repository)` → Repository → DatabaseHelper
+
+### 状態更新
+
+データ変更後は `ref.invalidateSelf()` で再取得する。
+
+## コーディング規約
+
+### 厳守ルール
+
+- シングルクォート（`'text'`）
+- package importのみ（`import 'package:book_manager/...'`、相対import禁止）
+- 変数は `final` を優先
+- Widget生成時は `const` を検討
+- 戻り値型を常に宣言
+- `@override` アノテーション必須
+- `super` パラメータを使用（`super.key`）
+- `print()` 禁止 → `debugPrint()` を使用
+- strict-casts / strict-raw-types 有効
+
+### 非同期処理
+
+- `async void` 禁止 → `Future<void>` を返す
+- await不要なFutureは `unawaited()` でラップ
+- Futureを無視しない（`discarded_futures`）
+- StreamSubscription / Sink は必ず解放
+
+### スタイル
+
+- if/for/while に常に `{}`
+- クラス内でコンストラクタを最初に配置
+- importは `directives_ordering` に従い整列
+
+## 主要パターン
+
+### Widget
+
+```dart
+class MyScreen extends HookConsumerWidget {
+  const MyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useTextEditingController();
+    final booksAsync = ref.watch(booksProvider);
+    return booksAsync.when(
+      data: (books) => ...,
+      loading: () => const CircularProgressIndicator(),
+      error: (error, stack) => ...,
+    );
+  }
+}
+```
+
+### Model（nullableフィールドのcopyWithにはセンチネルパターン）
+
+```dart
+static const _sentinel = Object();
+Book copyWith({Object? memo = _sentinel}) {
+  return Book(memo: memo == _sentinel ? this.memo : memo as String?);
+}
+```
+
+## データベース
+
+- SQLite（sqflite）+ UUID
+- DatabaseHelperはシングルトン
+- スキーマバージョン管理で `_onUpgrade()` によるマイグレーション
+
+## Git規約
+
+- ベースブランチ: `develop`
+- ブランチ命名: `feature/機能名`, `fix/バグ内容`, `refactor/対象`, `docs/内容`
+- コミットメッセージ: `種別: 変更内容の要約`（feat / fix / docs / refactor / test / chore）
+
+## 言語
+
+- コード（変数名・関数名・クラス名）: **英語**
+- UIテキスト・コメント・ドキュメント・PRレビュー: **日本語**

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -277,13 +277,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:book_manager/screens/home_screen.dart';
+import 'package:book_manager/screens/main_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -40,7 +40,7 @@ class BookManagerApp extends StatelessWidget {
           filled: true,
         ),
       ),
-      home: const HomeScreen(),
+      home: const MainScreen(),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,6 @@
 import 'package:book_manager/models/book.dart';
 import 'package:book_manager/providers/books_provider.dart';
 import 'package:book_manager/screens/book_detail_screen.dart';
-import 'package:book_manager/screens/book_form_screen.dart';
 import 'package:book_manager/widgets/book_card.dart';
 import 'package:book_manager/widgets/status_filter.dart';
 import 'package:flutter/material.dart';
@@ -104,11 +103,6 @@ class HomeScreen extends HookConsumerWidget {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => _navigateToAddBook(context),
-        icon: const Icon(Icons.add),
-        label: const Text('本を追加'),
-      ),
     );
   }
 
@@ -131,7 +125,7 @@ class HomeScreen extends HookConsumerWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            '右下のボタンから本を追加してください',
+            '下の＋ボタンから本を追加してください',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: Colors.grey[500],
                 ),
@@ -180,14 +174,6 @@ class HomeScreen extends HookConsumerWidget {
           onTap: () => _navigateToDetail(context, book.id),
         );
       },
-    );
-  }
-
-  Future<void> _navigateToAddBook(BuildContext context) async {
-    await Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => const BookFormScreen(),
-      ),
     );
   }
 

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:book_manager/screens/book_form_screen.dart';
 import 'package:book_manager/screens/home_screen.dart';
 import 'package:book_manager/screens/settings_screen.dart';
@@ -29,11 +31,13 @@ class MainScreen extends HookConsumerWidget {
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: selectedIndex.value,
-        onDestinationSelected: (index) async {
+        onDestinationSelected: (index) {
           if (index == _addIndex) {
-            await Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const BookFormScreen(),
+            unawaited(
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const BookFormScreen(),
+                ),
               ),
             );
             return;

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,0 +1,68 @@
+import 'package:book_manager/screens/book_form_screen.dart';
+import 'package:book_manager/screens/home_screen.dart';
+import 'package:book_manager/screens/settings_screen.dart';
+import 'package:book_manager/screens/statistics_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// メイン画面（ボトムナビゲーション付き）
+class MainScreen extends HookConsumerWidget {
+  const MainScreen({super.key});
+
+  // 追加ボタン（index 2）を除いたタブインデックスのマッピング
+  static const _addIndex = 2;
+  static const _navToStack = {0: 0, 1: 1, 3: 2};
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedIndex = useState(0);
+
+    return Scaffold(
+      body: IndexedStack(
+        index: _navToStack[selectedIndex.value] ?? 0,
+        children: const [
+          HomeScreen(),
+          StatisticsScreen(),
+          SettingsScreen(),
+        ],
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: selectedIndex.value,
+        onDestinationSelected: (index) async {
+          if (index == _addIndex) {
+            await Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => const BookFormScreen(),
+              ),
+            );
+            return;
+          }
+          selectedIndex.value = index;
+        },
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.library_books_outlined),
+            selectedIcon: Icon(Icons.library_books),
+            label: '本棚',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.bar_chart_outlined),
+            selectedIcon: Icon(Icons.bar_chart),
+            label: '統計',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.add_circle_outline, size: 32),
+            selectedIcon: Icon(Icons.add_circle_outline, size: 32),
+            label: '追加',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.settings_outlined),
+            selectedIcon: Icon(Icons.settings),
+            label: '設定',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 設定画面
+class SettingsScreen extends ConsumerWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('設定'),
+        centerTitle: true,
+      ),
+      body: ListView(
+        children: [
+          // アプリ情報セクション
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              'アプリ情報',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+            ),
+          ),
+          const ListTile(
+            leading: Icon(Icons.info_outline),
+            title: Text('アプリ名'),
+            subtitle: Text('読書管理'),
+          ),
+          const ListTile(
+            leading: Icon(Icons.new_releases_outlined),
+            title: Text('バージョン'),
+            subtitle: Text('1.0.0'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/statistics_screen.dart
+++ b/lib/screens/statistics_screen.dart
@@ -1,0 +1,180 @@
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/providers/books_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 読書統計画面
+class StatisticsScreen extends ConsumerWidget {
+  const StatisticsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final booksAsync = ref.watch(booksProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('統計'),
+        centerTitle: true,
+      ),
+      body: booksAsync.when(
+        data: (books) {
+          if (books.isEmpty) {
+            return _buildEmptyState(context);
+          }
+          return _buildStatistics(context, books);
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => const Center(
+          child: Text('エラーが発生しました'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.bar_chart,
+            size: 80,
+            color: Colors.grey[400],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '本を登録すると統計が表示されます',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatistics(BuildContext context, List<Book> books) {
+    final total = books.length;
+    final unreadCount =
+        books.where((b) => b.status == ReadingStatus.unread).length;
+    final readingCount =
+        books.where((b) => b.status == ReadingStatus.reading).length;
+    final completedCount =
+        books.where((b) => b.status == ReadingStatus.completed).length;
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // サマリーカード
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              children: [
+                Text(
+                  '登録冊数',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '$total冊',
+                  style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        // ステータス別内訳カード
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'ステータス別内訳',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 16),
+                _StatusRow(
+                  label: '未読',
+                  count: unreadCount,
+                  total: total,
+                  color: Colors.grey,
+                ),
+                const SizedBox(height: 12),
+                _StatusRow(
+                  label: '読書中',
+                  count: readingCount,
+                  total: total,
+                  color: Colors.blue,
+                ),
+                const SizedBox(height: 12),
+                _StatusRow(
+                  label: '読了',
+                  count: completedCount,
+                  total: total,
+                  color: Colors.green,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  const _StatusRow({
+    required this.label,
+    required this.count,
+    required this.total,
+    required this.color,
+  });
+
+  final String label;
+  final int count;
+  final int total;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final ratio = total > 0 ? count / total : 0.0;
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: color,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            Text(
+              '$count冊',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        LinearProgressIndicator(
+          value: ratio,
+          backgroundColor: color.withValues(alpha: 0.15),
+          valueColor: AlwaysStoppedAnimation<Color>(color),
+          minHeight: 8,
+          borderRadius: BorderRadius.circular(4),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/statistics_screen.dart
+++ b/lib/screens/statistics_screen.dart
@@ -24,8 +24,28 @@ class StatisticsScreen extends ConsumerWidget {
           return _buildStatistics(context, books);
         },
         loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) => const Center(
-          child: Text('エラーが発生しました'),
+        error: (error, stackTrace) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.error_outline,
+                size: 48,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'エラーが発生しました',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                error.toString(),
+                style: Theme.of(context).textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -407,10 +407,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -644,10 +644,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -391,26 +391,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -644,10 +644,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,8 +12,20 @@ void main() {
 
     // アプリタイトルが表示されることを確認
     expect(find.text('読書管理'), findsOneWidget);
+  });
 
-    // 本を追加ボタンが表示されることを確認
-    expect(find.text('本を追加'), findsOneWidget);
+  testWidgets('Navigation bar displays all tab labels',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: BookManagerApp(),
+      ),
+    );
+
+    // ナビゲーションバーのラベルが表示されることを確認
+    expect(find.text('本棚'), findsOneWidget);
+    expect(find.text('統計'), findsOneWidget);
+    expect(find.text('追加'), findsOneWidget);
+    expect(find.text('設定'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,4 +1,6 @@
 import 'package:book_manager/main.dart';
+import 'package:book_manager/screens/book_form_screen.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -27,5 +29,82 @@ void main() {
     expect(find.text('統計'), findsOneWidget);
     expect(find.text('追加'), findsOneWidget);
     expect(find.text('設定'), findsOneWidget);
+  });
+
+  testWidgets('Tapping statistics tab shows statistics screen',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: BookManagerApp(),
+      ),
+    );
+
+    // 統計タブをタップ
+    await tester.tap(find.text('統計'));
+    await tester.pumpAndSettle();
+
+    // 統計画面のAppBarタイトルが表示されることを確認
+    expect(find.text('統計'), findsNWidgets(2)); // ナビラベル + AppBarタイトル
+  });
+
+  testWidgets('Tapping settings tab shows settings screen',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: BookManagerApp(),
+      ),
+    );
+
+    // 設定タブをタップ
+    await tester.tap(find.text('設定'));
+    await tester.pumpAndSettle();
+
+    // 設定画面の内容が表示されることを確認
+    expect(find.text('設定'), findsNWidgets(2)); // ナビラベル + AppBarタイトル
+    expect(find.text('バージョン'), findsOneWidget);
+    expect(find.text('1.0.0'), findsOneWidget);
+  });
+
+  testWidgets('Tapping add button navigates to BookFormScreen',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: BookManagerApp(),
+      ),
+    );
+
+    // 追加ボタンをタップ
+    await tester.tap(find.text('追加'));
+    await tester.pumpAndSettle();
+
+    // BookFormScreenに遷移したことを確認
+    expect(find.byType(BookFormScreen), findsOneWidget);
+  });
+
+  testWidgets('Tab state is preserved when switching tabs',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: BookManagerApp(),
+      ),
+    );
+
+    // 検索バーにテキストを入力
+    final searchField = find.byType(TextField);
+    await tester.enterText(searchField, 'テスト検索');
+    await tester.pumpAndSettle();
+
+    // 設定タブに切り替え
+    await tester.tap(find.text('設定'));
+    await tester.pumpAndSettle();
+
+    // 本棚タブに戻る
+    await tester.tap(find.text('本棚'));
+    await tester.pumpAndSettle();
+
+    // 検索テキストが保持されていることを確認
+    final textField =
+        tester.widget<TextField>(find.byType(TextField).first);
+    expect(textField.controller?.text, 'テスト検索');
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,16 +1,33 @@
 import 'package:book_manager/main.dart';
+import 'package:book_manager/models/book.dart';
+import 'package:book_manager/providers/books_provider.dart';
 import 'package:book_manager/screens/book_form_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+/// テスト用のProviderScope（実DBに依存しない）
+ProviderScope createTestApp() {
+  return ProviderScope(
+    overrides: [
+      booksProvider.overrideWith(() => _FakeBooksNotifier()),
+    ],
+    child: const BookManagerApp(),
+  );
+}
+
+/// テスト用のBooksNotifier（空のリストを返す）
+class _FakeBooksNotifier extends BooksNotifier {
+  @override
+  Future<List<Book>> build() async {
+    return [];
+  }
+}
+
 void main() {
   testWidgets('App loads with home screen', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: BookManagerApp(),
-      ),
-    );
+    await tester.pumpWidget(createTestApp());
+    await tester.pumpAndSettle();
 
     // アプリタイトルが表示されることを確認
     expect(find.text('読書管理'), findsOneWidget);
@@ -18,11 +35,8 @@ void main() {
 
   testWidgets('Navigation bar displays all tab labels',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: BookManagerApp(),
-      ),
-    );
+    await tester.pumpWidget(createTestApp());
+    await tester.pumpAndSettle();
 
     // ナビゲーションバーのラベルが表示されることを確認
     expect(find.text('本棚'), findsOneWidget);
@@ -33,11 +47,8 @@ void main() {
 
   testWidgets('Tapping statistics tab shows statistics screen',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: BookManagerApp(),
-      ),
-    );
+    await tester.pumpWidget(createTestApp());
+    await tester.pumpAndSettle();
 
     // 統計タブをタップ
     await tester.tap(find.text('統計'));
@@ -49,11 +60,8 @@ void main() {
 
   testWidgets('Tapping settings tab shows settings screen',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: BookManagerApp(),
-      ),
-    );
+    await tester.pumpWidget(createTestApp());
+    await tester.pumpAndSettle();
 
     // 設定タブをタップ
     await tester.tap(find.text('設定'));
@@ -67,11 +75,8 @@ void main() {
 
   testWidgets('Tapping add button navigates to BookFormScreen',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: BookManagerApp(),
-      ),
-    );
+    await tester.pumpWidget(createTestApp());
+    await tester.pumpAndSettle();
 
     // 追加ボタンをタップ
     await tester.tap(find.text('追加'));
@@ -83,11 +88,8 @@ void main() {
 
   testWidgets('Tab state is preserved when switching tabs',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: BookManagerApp(),
-      ),
-    );
+    await tester.pumpWidget(createTestApp());
+    await tester.pumpAndSettle();
 
     // 検索バーにテキストを入力
     final searchField = find.byType(TextField);


### PR DESCRIPTION
## Summary
- `.github/copilot-instructions.md` を新規作成（GitHub Copilot向け）
- `CLAUDE.md` を新規作成（Claude Code向け）

### 注意
このPRは `feature/bottom-navigation-bar` ブランチ（PR #41）をベースに作成されています。
ボトムナビゲーション・統計画面・設定画面の変更は PR #41 で個別にレビュー済みです。
PR #41 マージ後にこのPRの差分はドキュメント変更のみになります。

### 含まれる内容（ドキュメント）
- プロジェクトのアーキテクチャ（Riverpod + Hooks の4層構成）
- コーディング規約（analysis_options.yaml に基づくルール）
- 状態管理・モデル定義・非同期処理のパターンとコード例
- データベース・テスト・Git規約
- 言語ルール（コードは英語、UI/コメント/PRレビューは日本語）

## Test plan
- [x] `copilot-instructions.md` の内容がプロジェクトの規約と一致していることを確認
- [x] `CLAUDE.md` の内容がプロジェクトの規約と一致していることを確認
- [x] 既存のコード・設定ファイルに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)